### PR TITLE
fix: improve data consistency and completeness

### DIFF
--- a/data/pokemon/pokemon.json
+++ b/data/pokemon/pokemon.json
@@ -13,17 +13,24 @@
             "shiny": null,
             "gmax": null
         },
-        "types": null,
-        "talents": null,
-        "stats": null,
-        "resistances": null,
+        "types": [],
+        "talents": [],
+        "stats": {
+            "hp": 0,
+            "atk": 0,
+            "def": 0,
+            "spe_atk": 0,
+            "spe_def": 0,
+            "vit": 0
+        },
+        "resistances": [],
         "evolution": null,
-        "height": null,
-        "weight": null,
+        "height": "",
+        "weight": "",
         "egg_groups": null,
         "sexe": null,
-        "catch_rate": null,
-        "level_100": null,
+        "catch_rate": 0,
+        "level_100": 0,
         "formes": null
     },
     {
@@ -293,7 +300,7 @@
                 {
                     "pokedex_id": 1,
                     "name": "Bulbizarre",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -443,12 +450,12 @@
                 {
                     "pokedex_id": 1,
                     "name": "Bulbizarre",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 2,
                     "name": "Herbizarre",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 }
             ],
             "next": null,
@@ -735,7 +742,7 @@
                 {
                     "pokedex_id": 4,
                     "name": "Salam\u00e8che",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -885,12 +892,12 @@
                 {
                     "pokedex_id": 4,
                     "name": "Salam\u00e8che",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 5,
                     "name": "Reptincel",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -1184,7 +1191,7 @@
                 {
                     "pokedex_id": 7,
                     "name": "Carapuce",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -1330,12 +1337,12 @@
                 {
                     "pokedex_id": 7,
                     "name": "Carapuce",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 8,
                     "name": "Carabaffe",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -1617,7 +1624,7 @@
                 {
                     "pokedex_id": 10,
                     "name": "Chenipan",
-                    "condition":"Niveau 7"
+                    "condition": "Niveau 7"
                 }
             ],
             "next": [
@@ -1766,12 +1773,12 @@
                 {
                     "pokedex_id": 10,
                     "name": "Chenipan",
-                    "condition":"Niveau 7"
+                    "condition": "Niveau 7"
                 },
                 {
                     "pokedex_id": 11,
                     "name": "Chrysacier",
-                    "condition":"Niveau 10"
+                    "condition": "Niveau 10"
                 }
             ],
             "next": null,
@@ -2052,7 +2059,7 @@
                 {
                     "pokedex_id": 13,
                     "name": "Aspicot",
-                    "condition":"Niveau 7"
+                    "condition": "Niveau 7"
                 }
             ],
             "next": [
@@ -2198,12 +2205,12 @@
                 {
                     "pokedex_id": 13,
                     "name": "Aspicot",
-                    "condition":"Niveau 7"
+                    "condition": "Niveau 7"
                 },
                 {
                     "pokedex_id": 14,
                     "name": "Coconfort",
-                    "condition":"Niveau 10"
+                    "condition": "Niveau 10"
                 }
             ],
             "next": null,
@@ -2496,7 +2503,7 @@
                 {
                     "pokedex_id": 16,
                     "name": "Roucool",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 }
             ],
             "next": [
@@ -2646,12 +2653,12 @@
                 {
                     "pokedex_id": 16,
                     "name": "Roucool",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 },
                 {
                     "pokedex_id": 17,
                     "name": "Roucoups",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -2948,7 +2955,7 @@
                 {
                     "pokedex_id": 19,
                     "name": "Rattata",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 }
             ],
             "next": null,
@@ -3237,7 +3244,7 @@
                 {
                     "pokedex_id": 21,
                     "name": "Piafabec",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 }
             ],
             "next": null,
@@ -3518,7 +3525,7 @@
                 {
                     "pokedex_id": 23,
                     "name": "Abo",
-                    "condition":"Niveau 22"
+                    "condition": "Niveau 22"
                 }
             ],
             "next": null,
@@ -3658,7 +3665,7 @@
                 {
                     "pokedex_id": 172,
                     "name": "Pichu",
-                    "condition":"Bonheur"
+                    "condition": "Bonheur"
                 }
             ],
             "next": [
@@ -3801,12 +3808,12 @@
                 {
                     "pokedex_id": 172,
                     "name": "Pichu",
-                    "condition":"+1 Niveau + Bonheur"
+                    "condition": "+1 Niveau + Bonheur"
                 },
                 {
                     "pokedex_id": 25,
                     "name": "Pikachu",
-                    "condition":"Pierre Foudre"
+                    "condition": "Pierre Foudre"
                 }
             ],
             "next": null,
@@ -4096,8 +4103,8 @@
             "pre": [
                 {
                     "pokedex_id": 27,
-                    "name": "Sabelette", 
-                    "condition":"Niveau 22"
+                    "name": "Sabelette",
+                    "condition": "Niveau 22"
                 }
             ],
             "next": null,
@@ -4392,7 +4399,7 @@
                 {
                     "pokedex_id": 29,
                     "name": "Nidoran\u2640",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -4540,12 +4547,12 @@
                 {
                     "pokedex_id": 29,
                     "name": "Nidoran\u2640",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 30,
                     "name": "Nidorina",
-                    "condition":"Pierre Lune"
+                    "condition": "Pierre Lune"
                 }
             ],
             "next": null,
@@ -4829,7 +4836,7 @@
                 {
                     "pokedex_id": 32,
                     "name": "Nidoran\u2642",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -4980,12 +4987,12 @@
                 {
                     "pokedex_id": 32,
                     "name": "Nidoran\u2642",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 33,
                     "name": "Nidorino",
-                    "condition":"Pierre Lune"
+                    "condition": "Pierre Lune"
                 }
             ],
             "next": null,
@@ -5126,7 +5133,7 @@
                 {
                     "pokedex_id": 173,
                     "name": "M\u00e9lo",
-                    "condition":"Bonheur"
+                    "condition": "Bonheur"
                 }
             ],
             "next": [
@@ -5272,12 +5279,12 @@
                 {
                     "pokedex_id": 173,
                     "name": "M\u00e9lo",
-                    "condition":"Bonheur"
+                    "condition": "Bonheur"
                 },
                 {
                     "pokedex_id": 35,
                     "name": "M\u00e9lof\u00e9e",
-                    "condition":"Pierre Lune"
+                    "condition": "Pierre Lune"
                 }
             ],
             "next": null,
@@ -5558,7 +5565,7 @@
                 {
                     "pokedex_id": 37,
                     "name": "Goupix",
-                    "condition":"Pierre Feu"
+                    "condition": "Pierre Feu"
                 }
             ],
             "next": null,
@@ -5711,7 +5718,7 @@
                 {
                     "pokedex_id": 174,
                     "name": "Toudoudou",
-                    "condition":"Bonheur"
+                    "condition": "Bonheur"
                 }
             ],
             "next": [
@@ -5861,12 +5868,12 @@
                 {
                     "pokedex_id": 174,
                     "name": "Toudoudou",
-                    "condition":"Bonheur"
+                    "condition": "Bonheur"
                 },
                 {
                     "pokedex_id": 39,
                     "name": "Rondoudou",
-                    "condition":"Pierre Lune"
+                    "condition": "Pierre Lune"
                 }
             ],
             "next": null,
@@ -6151,7 +6158,7 @@
                 {
                     "pokedex_id": 41,
                     "name": "Nosferapti",
-                    "condition":"Niveau 22"
+                    "condition": "Niveau 22"
                 }
             ],
             "next": [
@@ -6447,7 +6454,7 @@
                 {
                     "pokedex_id": 43,
                     "name": "Mystherbe",
-                    "condition":"Niveau 21"
+                    "condition": "Niveau 21"
                 }
             ],
             "next": [
@@ -6598,12 +6605,12 @@
                 {
                     "pokedex_id": 43,
                     "name": "Mystherbe",
-                    "condition":"Niveau 21"
+                    "condition": "Niveau 21"
                 },
                 {
                     "pokedex_id": 44,
                     "name": "Ortide",
-                    "condition":"Pierre Plante"
+                    "condition": "Pierre Plante"
                 }
             ],
             "next": null,
@@ -6892,7 +6899,7 @@
                 {
                     "pokedex_id": 46,
                     "name": "Paras",
-                    "condition":"Niveau 24"
+                    "condition": "Niveau 24"
                 }
             ],
             "next": null,
@@ -7181,7 +7188,7 @@
                 {
                     "pokedex_id": 48,
                     "name": "Mimitoss",
-                    "condition":"Niveau 31"
+                    "condition": "Niveau 31"
                 }
             ],
             "next": null,
@@ -7470,7 +7477,7 @@
                 {
                     "pokedex_id": 50,
                     "name": "Taupiqueur",
-                    "condition":"Niveau 26"
+                    "condition": "Niveau 26"
                 }
             ],
             "next": null,
@@ -7779,7 +7786,7 @@
                 {
                     "pokedex_id": 52,
                     "name": "Miaouss",
-                    "condition":"Niveau 28"
+                    "condition": "Niveau 28"
                 }
             ],
             "next": null,
@@ -8069,7 +8076,7 @@
                 {
                     "pokedex_id": 54,
                     "name": "Psykokwak",
-                    "condition":"Niveau 33"
+                    "condition": "Niveau 33"
                 }
             ],
             "next": null,
@@ -8355,7 +8362,7 @@
                 {
                     "pokedex_id": 56,
                     "name": "F\u00e9rosinge",
-                    "condition":"Niveau 28"
+                    "condition": "Niveau 28"
                 }
             ],
             "next": [
@@ -8650,7 +8657,7 @@
                 {
                     "pokedex_id": 58,
                     "name": "Caninos",
-                    "condition":"Pierre Feu"
+                    "condition": "Pierre Feu"
                 }
             ],
             "next": null,
@@ -8949,7 +8956,7 @@
                 {
                     "pokedex_id": 60,
                     "name": "Ptitard",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 }
             ],
             "next": [
@@ -9104,12 +9111,12 @@
                 {
                     "pokedex_id": 60,
                     "name": "Ptitard",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 },
                 {
                     "pokedex_id": 61,
                     "name": "T\u00eatarte",
-                    "condition":"Pierre Eau"
+                    "condition": "Pierre Eau"
                 }
             ],
             "next": null,
@@ -9394,7 +9401,7 @@
                 {
                     "pokedex_id": 63,
                     "name": "Abra",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -13833,7 +13840,7 @@
                 },
                 {
                     "pokedex_id": 93,
-                    "name": "Spectrum", 
+                    "name": "Spectrum",
                     "condition": "Echange/Au contact d'un Fil de Liaison"
                 }
             ],
@@ -15559,7 +15566,7 @@
                 {
                     "pokedex_id": 236,
                     "name": "Debugant",
-                    "condition":"Niveau 20 + Attaque > D\u00e9fense"
+                    "condition": "Niveau 20 + Attaque > D\u00e9fense"
                 }
             ],
             "next": null,
@@ -15699,7 +15706,7 @@
                 {
                     "pokedex_id": 236,
                     "name": "Debugant",
-                    "condition":"Niveau 20 + Attaque < D\u00e9fense"
+                    "condition": "Niveau 20 + Attaque < D\u00e9fense"
                 }
             ],
             "next": null,
@@ -16569,14 +16576,14 @@
                 {
                     "pokedex_id": 440,
                     "name": "Ptiravi",
-                    "condition":"+1 Niveau la journ\u00e9e avec Pierre Ovale / Contact avec Pierre Ovale le jour (PLA)"
+                    "condition": "+1 Niveau la journ\u00e9e avec Pierre Ovale / Contact avec Pierre Ovale le jour (PLA)"
                 }
             ],
             "next": [
                 {
                     "pokedex_id": 242,
                     "name": "Leuphorie",
-                    "condition":"Bonheur"
+                    "condition": "Bonheur"
                 }
             ],
             "mega": null
@@ -17852,7 +17859,7 @@
                 {
                     "pokedex_id": 439,
                     "name": "Mime Jr.",
-                    "condition":"+1 Niveau avec Copie"
+                    "condition": "+1 Niveau avec Copie"
                 }
             ],
             "next": null,
@@ -18154,7 +18161,7 @@
                 {
                     "pokedex_id": 238,
                     "name": "Lippouti",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -18290,7 +18297,7 @@
                 {
                     "pokedex_id": 239,
                     "name": "\u00c9lekid",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": [
@@ -18432,7 +18439,7 @@
                 {
                     "pokedex_id": 240,
                     "name": "Magby",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": [
@@ -18996,7 +19003,7 @@
                 {
                     "pokedex_id": 129,
                     "name": "Magicarpe",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 }
             ],
             "next": null,
@@ -19580,7 +19587,7 @@
                 {
                     "pokedex_id": 133,
                     "name": "\u00c9voli",
-                    "condition":"Pierre Eau"
+                    "condition": "Pierre Eau"
                 }
             ],
             "next": null,
@@ -19716,7 +19723,7 @@
                 {
                     "pokedex_id": 133,
                     "name": "\u00c9voli",
-                    "condition":"Pierre Foudre"
+                    "condition": "Pierre Foudre"
                 }
             ],
             "next": null,
@@ -19852,7 +19859,7 @@
                 {
                     "pokedex_id": 133,
                     "name": "\u00c9voli",
-                    "condition":"Pierre Feu"
+                    "condition": "Pierre Feu"
                 }
             ],
             "next": null,
@@ -20283,7 +20290,7 @@
                 {
                     "pokedex_id": 138,
                     "name": "Amonita",
-                    "condition":"Niveau 40"
+                    "condition": "Niveau 40"
                 }
             ],
             "next": null,
@@ -20859,7 +20866,7 @@
             }
         ],
         "evolution": {
-            "pre":  [
+            "pre": [
                 {
                     "pokedex_id": 143,
                     "name": "Ronflex",
@@ -22212,7 +22219,7 @@
                 {
                     "pokedex_id": 152,
                     "name": "Germignon",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -22355,12 +22362,12 @@
                 {
                     "pokedex_id": 152,
                     "name": "Germignon",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 153,
                     "name": "Macronium",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 }
             ],
             "next": null,
@@ -22795,7 +22802,7 @@
                 {
                     "pokedex_id": 156,
                     "name": "Feurisson",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -23082,7 +23089,7 @@
                 {
                     "pokedex_id": 158,
                     "name": "Kaiminus",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 }
             ],
             "next": [
@@ -23225,12 +23232,12 @@
                 {
                     "pokedex_id": 158,
                     "name": "Kaiminus",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 },
                 {
                     "pokedex_id": 159,
                     "name": "Crocodil",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -23511,7 +23518,7 @@
                 {
                     "pokedex_id": 161,
                     "name": "Fouinette",
-                    "condition":"Niveau 15"
+                    "condition": "Niveau 15"
                 }
             ],
             "next": null,
@@ -23799,7 +23806,7 @@
                 {
                     "pokedex_id": 163,
                     "name": "Hoothoot",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 }
             ],
             "next": null,
@@ -24087,7 +24094,7 @@
                 {
                     "pokedex_id": 165,
                     "name": "Coxy",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 }
             ],
             "next": null,
@@ -24375,7 +24382,7 @@
                 {
                     "pokedex_id": 167,
                     "name": "Mimigal",
-                    "condition":"Niveau 22"
+                    "condition": "Niveau 22"
                 }
             ],
             "next": null,
@@ -24515,12 +24522,12 @@
                 {
                     "pokedex_id": 41,
                     "name": "Nosferapti",
-                    "condition":"Niveau 22"
+                    "condition": "Niveau 22"
                 },
                 {
                     "pokedex_id": 42,
                     "name": "Nosferalto",
-                    "condition":"+1 Niveau + Bonheur"
+                    "condition": "+1 Niveau + Bonheur"
                 }
             ],
             "next": null,
@@ -24808,7 +24815,7 @@
                 {
                     "pokedex_id": 170,
                     "name": "Loupio",
-                    "condition":"Niveau 27"
+                    "condition": "Niveau 27"
                 }
             ],
             "next": null,
@@ -25524,7 +25531,7 @@
                 {
                     "pokedex_id": 175,
                     "name": "Togepi",
-                    "condition":"+1 Niveau + Bonheur"
+                    "condition": "+1 Niveau + Bonheur"
                 }
             ],
             "next": [
@@ -25819,7 +25826,7 @@
                 {
                     "pokedex_id": 177,
                     "name": "Natu",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 }
             ],
             "next": null,
@@ -26097,7 +26104,7 @@
                 {
                     "pokedex_id": 179,
                     "name": "Wattouat",
-                    "condition":"Niveau 15"
+                    "condition": "Niveau 15"
                 }
             ],
             "next": [
@@ -26240,12 +26247,12 @@
                 {
                     "pokedex_id": 179,
                     "name": "Wattouat",
-                    "condition":"Niveau 15"
+                    "condition": "Niveau 15"
                 },
                 {
                     "pokedex_id": 180,
                     "name": "Lainergie",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -26390,12 +26397,12 @@
                 {
                     "pokedex_id": 43,
                     "name": "Mytherbe",
-                    "condition":"Niveau 21"
+                    "condition": "Niveau 21"
                 },
                 {
                     "pokedex_id": 44,
                     "name": "Ortide",
-                    "condition":"Pierre Soleil"
+                    "condition": "Pierre Soleil"
                 }
             ],
             "next": null,
@@ -26539,14 +26546,14 @@
                 {
                     "pokedex_id": 298,
                     "name": "Azurill",
-                    "condition":"+1 Niveau + Bonheur"
+                    "condition": "+1 Niveau + Bonheur"
                 }
             ],
             "next": [
                 {
                     "pokedex_id": 184,
                     "name": "Azumarill",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 }
             ],
             "mega": null
@@ -26690,12 +26697,12 @@
                 {
                     "pokedex_id": 298,
                     "name": "Azurill",
-                    "condition":"+1 Niveau + Bonheur"
+                    "condition": "+1 Niveau + Bonheur"
                 },
                 {
                     "pokedex_id": 183,
                     "name": "Marill",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 }
             ],
             "next": null,
@@ -26836,7 +26843,7 @@
                 {
                     "pokedex_id": 438,
                     "name": "Manza\u00ed",
-                    "condition":"Connaitre Copie + 1 Niveau"
+                    "condition": "Connaitre Copie + 1 Niveau"
                 }
             ],
             "next": null,
@@ -26976,12 +26983,12 @@
                 {
                     "pokedex_id": 60,
                     "name": "Ptitard",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 },
                 {
                     "pokedex_id": 61,
                     "name": "T\u00eatarte",
-                    "condition":"Echange avec Roche Royale"
+                    "condition": "Echange avec Roche Royale"
                 }
             ],
             "next": null,
@@ -27275,7 +27282,7 @@
                 {
                     "pokedex_id": 187,
                     "name": "Granivol",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 }
             ],
             "next": [
@@ -27426,12 +27433,12 @@
                 {
                     "pokedex_id": 187,
                     "name": "Granivol",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 },
                 {
                     "pokedex_id": 188,
                     "name": "Cotovol",
-                    "condition":"Niveau 27"
+                    "condition": "Niveau 27"
                 }
             ],
             "next": null,
@@ -27852,7 +27859,7 @@
                 {
                     "pokedex_id": 191,
                     "name": "Tournegrin",
-                    "condition":"Pierre Soleil"
+                    "condition": "Pierre Soleil"
                 }
             ],
             "next": null,
@@ -28294,7 +28301,7 @@
                 {
                     "pokedex_id": 194,
                     "name": "Axoloto",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 }
             ],
             "next": null,
@@ -28431,7 +28438,7 @@
                 {
                     "pokedex_id": 133,
                     "name": "\u00c9voli",
-                    "condition":"Bonheur + Jour + 1 niveau + aucune capacit\u00e9 F\u00e9e"
+                    "condition": "Bonheur + Jour + 1 niveau + aucune capacit\u00e9 F\u00e9e"
                 }
             ],
             "next": null,
@@ -28567,7 +28574,7 @@
                 {
                     "pokedex_id": 133,
                     "name": "\u00c9voli",
-                    "condition":"Bonheur + Nuit + 1 niveau + aucune capacit\u00e9 F\u00e9e"
+                    "condition": "Bonheur + Nuit + 1 niveau + aucune capacit\u00e9 F\u00e9e"
                 }
             ],
             "next": null,
@@ -28855,7 +28862,7 @@
                 {
                     "pokedex_id": 79,
                     "name": "Ramoloss",
-                    "condition":"Echange Ramoloss avec Roche Royale"
+                    "condition": "Echange Ramoloss avec Roche Royale"
                 }
             ],
             "next": null,
@@ -29250,7 +29257,7 @@
                 {
                     "pokedex_id": 360,
                     "name": "Ok\u00e9ok\u00e9",
-                    "condition":"Niveau 15"
+                    "condition": "Niveau 15"
                 }
             ],
             "next": null,
@@ -29670,7 +29677,7 @@
                 {
                     "pokedex_id": 204,
                     "name": "Pomdepik",
-                    "condition":"Niveau 31"
+                    "condition": "Niveau 31"
                 }
             ],
             "next": null,
@@ -30098,7 +30105,7 @@
                 {
                     "pokedex_id": 95,
                     "name": "Onix",
-                    "condition":"Echange avec Peau M\u00e9tal / Au contact d'une Peau M\u00e9tal (PLA)"
+                    "condition": "Echange avec Peau M\u00e9tal / Au contact d'une Peau M\u00e9tal (PLA)"
                 }
             ],
             "next": null,
@@ -30379,7 +30386,7 @@
                 {
                     "pokedex_id": 209,
                     "name": "Snubbull",
-                    "condition":"Niveau 23"
+                    "condition": "Niveau 23"
                 }
             ],
             "next": null,
@@ -30667,7 +30674,7 @@
                 {
                     "pokedex_id": 123,
                     "name": "Ins\u00e9cateur",
-                    "condition":"Echange avec Peau M\u00e9tal / Au contact d'une Peau M\u00e9tal (PLA)"
+                    "condition": "Echange avec Peau M\u00e9tal / Au contact d'une Peau M\u00e9tal (PLA)"
                 }
             ],
             "next": null,
@@ -31393,7 +31400,7 @@
                 {
                     "pokedex_id": 216,
                     "name": "Teddiursa",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": [
@@ -31683,7 +31690,7 @@
                 {
                     "pokedex_id": 218,
                     "name": "Limagma",
-                    "condition":"Niveau 38"
+                    "condition": "Niveau 38"
                 }
             ],
             "next": null,
@@ -31976,7 +31983,7 @@
                 {
                     "pokedex_id": 220,
                     "name": "Marcacrin",
-                    "condition":"Niveau 33"
+                    "condition": "Niveau 33"
                 }
             ],
             "next": [
@@ -32407,7 +32414,7 @@
                 {
                     "pokedex_id": 223,
                     "name": "R\u00e9moraid",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 }
             ],
             "next": null,
@@ -32687,7 +32694,7 @@
                 {
                     "pokedex_id": 458,
                     "name": "Babimanta",
-                    "condition":"Gain de niveau avec R\u00e9moraid dans l'\u00e9quipe"
+                    "condition": "Gain de niveau avec R\u00e9moraid dans l'\u00e9quipe"
                 }
             ],
             "next": null,
@@ -33109,7 +33116,7 @@
                 {
                     "pokedex_id": 228,
                     "name": "Malosse",
-                    "condition":"Niveau 24"
+                    "condition": "Niveau 24"
                 }
             ],
             "next": null,
@@ -33261,12 +33268,12 @@
                 {
                     "pokedex_id": 116,
                     "name": "Hypotrempe",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 },
                 {
                     "pokedex_id": 117,
                     "name": "Hypoc\u00e9an",
-                    "condition":"Echange avec \u00c9caille Draco"
+                    "condition": "Echange avec \u00c9caille Draco"
                 }
             ],
             "next": null,
@@ -33539,7 +33546,7 @@
                 {
                     "pokedex_id": 231,
                     "name": "Phanpy",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 }
             ],
             "next": null,
@@ -33679,7 +33686,7 @@
                 {
                     "pokedex_id": 137,
                     "name": "Porygon",
-                    "condition":"Echange avec Am\u00e9liorator/Contact d'un Am\u00e9liorator (PLA)"
+                    "condition": "Echange avec Am\u00e9liorator/Contact d'un Am\u00e9liorator (PLA)"
                 }
             ],
             "next": [
@@ -34240,7 +34247,7 @@
                 {
                     "pokedex_id": 236,
                     "name": "Debugant",
-                    "condition":"Niveau 20 + Attaque = D\u00e9fense"
+                    "condition": "Niveau 20 + Attaque = D\u00e9fense"
                 }
             ],
             "next": null,
@@ -34930,12 +34937,12 @@
                 {
                     "pokedex_id": 440,
                     "name": "Ptiravi",
-                    "condition":"+1 Niveau la journ\u00e9e avec Pierre Ovale / Contact avec Pierre Ovale le jour (PLA)"
+                    "condition": "+1 Niveau la journ\u00e9e avec Pierre Ovale / Contact avec Pierre Ovale le jour (PLA)"
                 },
                 {
                     "pokedex_id": 113,
                     "name": "Leveinard",
-                    "condition":"+1 Niveau + Bonheur"
+                    "condition": "+1 Niveau + Bonheur"
                 }
             ],
             "next": null,
@@ -35579,7 +35586,7 @@
                 {
                     "pokedex_id": 246,
                     "name": "Embrylex",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": [
@@ -35725,12 +35732,12 @@
                 {
                     "pokedex_id": 246,
                     "name": "Embrylex",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 },
                 {
                     "pokedex_id": 247,
                     "name": "Ymphect",
-                    "condition":"Niveau 55"
+                    "condition": "Niveau 55"
                 }
             ],
             "next": null,
@@ -36387,7 +36394,7 @@
                 {
                     "pokedex_id": 252,
                     "name": "Arcko",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -36530,12 +36537,12 @@
                 {
                     "pokedex_id": 252,
                     "name": "Arcko",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 253,
                     "name": "Massko",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -36825,7 +36832,7 @@
                 {
                     "pokedex_id": 255,
                     "name": "Poussifeu",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -36971,12 +36978,12 @@
                 {
                     "pokedex_id": 255,
                     "name": "Poussifeu",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 256,
                     "name": "Galifeu",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -37266,7 +37273,7 @@
                 {
                     "pokedex_id": 258,
                     "name": "Gobou",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -37413,12 +37420,12 @@
                 {
                     "pokedex_id": 258,
                     "name": "Gobou",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 259,
                     "name": "Flobio",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -37707,7 +37714,7 @@
                 {
                     "pokedex_id": 261,
                     "name": "Medhy\u00e8na",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 }
             ],
             "next": null,
@@ -37996,7 +38003,7 @@
                 {
                     "pokedex_id": 263,
                     "name": "Zigzaton",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 }
             ],
             "next": null,
@@ -38288,7 +38295,7 @@
                 {
                     "pokedex_id": 265,
                     "name": "Chenipotte",
-                    "condition":"Niveau 7"
+                    "condition": "Niveau 7"
                 }
             ],
             "next": [
@@ -38434,12 +38441,12 @@
                 {
                     "pokedex_id": 265,
                     "name": "Chenipotte",
-                    "condition":"Niveau 7"
+                    "condition": "Niveau 7"
                 },
                 {
                     "pokedex_id": 266,
                     "name": "Armulys",
-                    "condition":"Niveau 10"
+                    "condition": "Niveau 10"
                 }
             ],
             "next": null,
@@ -38571,7 +38578,7 @@
                 {
                     "pokedex_id": 265,
                     "name": "Chenipotte",
-                    "condition":"Niveau 7"
+                    "condition": "Niveau 7"
                 }
             ],
             "next": [
@@ -38717,12 +38724,12 @@
                 {
                     "pokedex_id": 265,
                     "name": "Chenipotte",
-                    "condition":"Niveau 7"
+                    "condition": "Niveau 7"
                 },
                 {
                     "pokedex_id": 268,
                     "name": "Blindalys",
-                    "condition":"Niveau 10"
+                    "condition": "Niveau 10"
                 }
             ],
             "next": null,
@@ -39016,7 +39023,7 @@
                 {
                     "pokedex_id": 270,
                     "name": "N\u00e9nupiot",
-                    "condition":"Niveau 14"
+                    "condition": "Niveau 14"
                 }
             ],
             "next": [
@@ -39167,12 +39174,12 @@
                 {
                     "pokedex_id": 270,
                     "name": "N\u00e9nupiot",
-                    "condition":"Niveau 14"
+                    "condition": "Niveau 14"
                 },
                 {
                     "pokedex_id": 271,
                     "name": "Lombre",
-                    "condition":"Pierre Eau"
+                    "condition": "Pierre Eau"
                 }
             ],
             "next": null,
@@ -39463,7 +39470,7 @@
                 {
                     "pokedex_id": 273,
                     "name": "Grainipiot",
-                    "condition":"Niveau 14"
+                    "condition": "Niveau 14"
                 }
             ],
             "next": [
@@ -39614,12 +39621,12 @@
                 {
                     "pokedex_id": 273,
                     "name": "Grainipiot",
-                    "condition":"Niveau 14"
+                    "condition": "Niveau 14"
                 },
                 {
                     "pokedex_id": 274,
                     "name": "Pifeuil",
-                    "condition":"Pierre Plante"
+                    "condition": "Pierre Plante"
                 }
             ],
             "next": null,
@@ -39900,7 +39907,7 @@
                 {
                     "pokedex_id": 276,
                     "name": "Nirondelle",
-                    "condition":"Niveau 22"
+                    "condition": "Niveau 22"
                 }
             ],
             "next": null,
@@ -40189,7 +40196,7 @@
                 {
                     "pokedex_id": 278,
                     "name": "Go\u00e9lise",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 }
             ],
             "next": null,
@@ -40489,7 +40496,7 @@
                 {
                     "pokedex_id": 280,
                     "name": "Tarsal",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 }
             ],
             "next": [
@@ -40645,12 +40652,12 @@
                 {
                     "pokedex_id": 280,
                     "name": "Tarsal",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 },
                 {
                     "pokedex_id": 281,
                     "name": "Kirlia",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -40940,7 +40947,7 @@
                 {
                     "pokedex_id": 283,
                     "name": "Arakdo",
-                    "condition":"Niveau 22"
+                    "condition": "Niveau 22"
                 }
             ],
             "next": null,
@@ -41226,7 +41233,7 @@
                 {
                     "pokedex_id": 285,
                     "name": "Balignon",
-                    "condition":"Niveau 23"
+                    "condition": "Niveau 23"
                 }
             ],
             "next": null,
@@ -41496,7 +41503,7 @@
                 {
                     "pokedex_id": 287,
                     "name": "Parecool",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 }
             ],
             "next": [
@@ -41634,12 +41641,12 @@
                 {
                     "pokedex_id": 287,
                     "name": "Parecool",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 },
                 {
                     "pokedex_id": 288,
                     "name": "Vigoroth",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -41924,7 +41931,7 @@
                 {
                     "pokedex_id": 290,
                     "name": "Ningale",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 }
             ],
             "next": null,
@@ -42060,7 +42067,7 @@
                 {
                     "pokedex_id": 290,
                     "name": "Ningale",
-                    "condition":"Niveau 20 + Pokeball + un emplacement de libre dans l'\u00e9quipe"
+                    "condition": "Niveau 20 + Pokeball + un emplacement de libre dans l'\u00e9quipe"
                 }
             ],
             "next": null,
@@ -42335,7 +42342,7 @@
                 {
                     "pokedex_id": 293,
                     "name": "Chuchmur",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 }
             ],
             "next": [
@@ -42478,12 +42485,12 @@
                 {
                     "pokedex_id": 293,
                     "name": "Chuchmur",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 },
                 {
                     "pokedex_id": 294,
                     "name": "Ramboum",
-                    "condition":"Niveau 40"
+                    "condition": "Niveau 40"
                 }
             ],
             "next": null,
@@ -42764,7 +42771,7 @@
                 {
                     "pokedex_id": 296,
                     "name": "Makuhita",
-                    "condition":"Niveau 24"
+                    "condition": "Niveau 24"
                 }
             ],
             "next": null,
@@ -43332,7 +43339,7 @@
                 {
                     "pokedex_id": 300,
                     "name": "Skitty",
-                    "condition":"Pierre Lune"
+                    "condition": "Pierre Lune"
                 }
             ],
             "next": null,
@@ -43919,7 +43926,7 @@
                 {
                     "pokedex_id": 304,
                     "name": "Galekid",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 }
             ],
             "next": [
@@ -44069,12 +44076,12 @@
                 {
                     "pokedex_id": 304,
                     "name": "Galekid",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 },
                 {
                     "pokedex_id": 305,
                     "name": "Galegon",
-                    "condition":"Niveau 42"
+                    "condition": "Niveau 42"
                 }
             ],
             "next": null,
@@ -44362,7 +44369,7 @@
                 {
                     "pokedex_id": 307,
                     "name": "M\u00e9ditikka",
-                    "condition":"Niveau 37"
+                    "condition": "Niveau 37"
                 }
             ],
             "next": null,
@@ -44650,7 +44657,7 @@
                 {
                     "pokedex_id": 309,
                     "name": "Dynavolt",
-                    "condition":"Niveau 26"
+                    "condition": "Niveau 26"
                 }
             ],
             "next": null,
@@ -45316,7 +45323,7 @@
                 {
                     "pokedex_id": 406,
                     "name": "Rozbouton",
-                    "condition":"Bonheur + Jour + 1 niveau"
+                    "condition": "Bonheur + Jour + 1 niveau"
                 }
             ],
             "next": [
@@ -45603,7 +45610,7 @@
                 {
                     "pokedex_id": 316,
                     "name": "Gloupti",
-                    "condition":"Niveau 26"
+                    "condition": "Niveau 26"
                 }
             ],
             "next": null,
@@ -45883,7 +45890,7 @@
                 {
                     "pokedex_id": 318,
                     "name": "Carvanha",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -46172,7 +46179,7 @@
                 {
                     "pokedex_id": 320,
                     "name": "Wailmer",
-                    "condition":"Niveau 40"
+                    "condition": "Niveau 40"
                 }
             ],
             "next": null,
@@ -46461,7 +46468,7 @@
                 {
                     "pokedex_id": 322,
                     "name": "Chamallot",
-                    "condition":"Niveau 33"
+                    "condition": "Niveau 33"
                 }
             ],
             "next": null,
@@ -46879,7 +46886,7 @@
                 {
                     "pokedex_id": 325,
                     "name": "Spoink",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 }
             ],
             "next": null,
@@ -47292,7 +47299,7 @@
                 {
                     "pokedex_id": 328,
                     "name": "Kraknoix",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 }
             ],
             "next": [
@@ -47435,12 +47442,12 @@
                 {
                     "pokedex_id": 328,
                     "name": "Kraknoix",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 },
                 {
                     "pokedex_id": 329,
                     "name": "Vibraninf",
-                    "condition":"Niveau 45"
+                    "condition": "Niveau 45"
                 }
             ],
             "next": null,
@@ -47718,7 +47725,7 @@
                 {
                     "pokedex_id": 331,
                     "name": "Cacnea",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 }
             ],
             "next": null,
@@ -48000,7 +48007,7 @@
                 {
                     "pokedex_id": 333,
                     "name": "Tylton",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 }
             ],
             "next": null,
@@ -48796,7 +48803,7 @@
                 {
                     "pokedex_id": 339,
                     "name": "Barloche",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -49081,7 +49088,7 @@
                 {
                     "pokedex_id": 341,
                     "name": "\u00c9crapince",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -49351,7 +49358,7 @@
                 {
                     "pokedex_id": 343,
                     "name": "Balbulto",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -49628,7 +49635,7 @@
                 {
                     "pokedex_id": 345,
                     "name": "Lilia",
-                    "condition":"Niveau 40"
+                    "condition": "Niveau 40"
                 }
             ],
             "next": null,
@@ -49908,7 +49915,7 @@
                 {
                     "pokedex_id": 347,
                     "name": "Anorith",
-                    "condition":"Niveau 40"
+                    "condition": "Niveau 40"
                 }
             ],
             "next": null,
@@ -50719,7 +50726,7 @@
                 {
                     "pokedex_id": 353,
                     "name": "Polichombr",
-                    "condition":"Niveau 37"
+                    "condition": "Niveau 37"
                 }
             ],
             "next": null,
@@ -51004,7 +51011,7 @@
                 {
                     "pokedex_id": 355,
                     "name": "Sk\u00e9l\u00e9nox",
-                    "condition":"Niveau 37"
+                    "condition": "Niveau 37"
                 }
             ],
             "next": [
@@ -51277,7 +51284,7 @@
                 {
                     "pokedex_id": 433,
                     "name": "Korillon",
-                    "condition":"+1 Niveau + Nuit + Bonheur"
+                    "condition": "+1 Niveau + Nuit + Bonheur"
                 }
             ],
             "next": null,
@@ -51839,7 +51846,7 @@
                 {
                     "pokedex_id": 361,
                     "name": "Stalgamin",
-                    "condition":"Niveau 42"
+                    "condition": "Niveau 42"
                 }
             ],
             "next": null,
@@ -52142,7 +52149,7 @@
                 {
                     "pokedex_id": 363,
                     "name": "Obalie",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 }
             ],
             "next": [
@@ -52293,12 +52300,12 @@
                 {
                     "pokedex_id": 363,
                     "name": "Obalie",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 },
                 {
                     "pokedex_id": 364,
                     "name": "Phogleur",
-                    "condition":"Niveau 44"
+                    "condition": "Niveau 44"
                 }
             ],
             "next": null,
@@ -52576,7 +52583,7 @@
                 {
                     "pokedex_id": 366,
                     "name": "Coquiperl",
-                    "condition":"Echange avec Dent Oc\u00e9an"
+                    "condition": "Echange avec Dent Oc\u00e9an"
                 }
             ],
             "next": null,
@@ -52712,7 +52719,7 @@
                 {
                     "pokedex_id": 366,
                     "name": "Coquiperl",
-                    "condition":"Echange avec \u00c9caille Oc\u00e9an"
+                    "condition": "Echange avec \u00c9caille Oc\u00e9an"
                 }
             ],
             "next": null,
@@ -53250,7 +53257,7 @@
                 {
                     "pokedex_id": 371,
                     "name": "Drabby",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": [
@@ -53396,12 +53403,12 @@
                 {
                     "pokedex_id": 371,
                     "name": "Drabby",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 },
                 {
                     "pokedex_id": 372,
                     "name": "Drackhaus",
-                    "condition":"Niveau 50"
+                    "condition": "Niveau 50"
                 }
             ],
             "next": null,
@@ -53691,7 +53698,7 @@
                 {
                     "pokedex_id": 374,
                     "name": "Terhal",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 }
             ],
             "next": [
@@ -53834,12 +53841,12 @@
                 {
                     "pokedex_id": 374,
                     "name": "Terhal",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 },
                 {
                     "pokedex_id": 375,
                     "name": "M\u00e9tang",
-                    "condition":"Niveau 45"
+                    "condition": "Niveau 45"
                 }
             ],
             "next": null,
@@ -55761,7 +55768,7 @@
                 {
                     "pokedex_id": 390,
                     "name": "Ouisticram",
-                    "condition":"Niveau 14"
+                    "condition": "Niveau 14"
                 }
             ],
             "next": [
@@ -55908,12 +55915,12 @@
                 {
                     "pokedex_id": 390,
                     "name": "Ouisticram",
-                    "condition":"Niveau 14"
+                    "condition": "Niveau 14"
                 },
                 {
                     "pokedex_id": 391,
                     "name": "Chimpenfeu",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -56192,7 +56199,7 @@
                 {
                     "pokedex_id": 393,
                     "name": "Tiplouf",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -56339,12 +56346,12 @@
                 {
                     "pokedex_id": 393,
                     "name": "Tiplouf",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 394,
                     "name": "Prinplouf",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -56630,7 +56637,7 @@
                 {
                     "pokedex_id": 396,
                     "name": "\u00c9tourmi",
-                    "condition":"Niveau 14"
+                    "condition": "Niveau 14"
                 }
             ],
             "next": [
@@ -56776,12 +56783,12 @@
                 {
                     "pokedex_id": 396,
                     "name": "\u00c9tourmi",
-                    "condition":"Niveau 14"
+                    "condition": "Niveau 14"
                 },
                 {
                     "pokedex_id": 397,
                     "name": "\u00c9tourvol",
-                    "condition":"Niveau 34"
+                    "condition": "Niveau 34"
                 }
             ],
             "next": null,
@@ -57066,7 +57073,7 @@
                 {
                     "pokedex_id": 399,
                     "name": "Keunotor",
-                    "condition":"Niveau 15"
+                    "condition": "Niveau 15"
                 }
             ],
             "next": null,
@@ -57339,7 +57346,7 @@
                 {
                     "pokedex_id": 401,
                     "name": "Crikzik",
-                    "condition":"Niveau 10"
+                    "condition": "Niveau 10"
                 }
             ],
             "next": null,
@@ -57624,7 +57631,7 @@
                 {
                     "pokedex_id": 403,
                     "name": "Lixy",
-                    "condition":"Niveau 15"
+                    "condition": "Niveau 15"
                 }
             ],
             "next": [
@@ -57770,12 +57777,12 @@
                 {
                     "pokedex_id": 403,
                     "name": "Lixy",
-                    "condition":"Niveau 15"
+                    "condition": "Niveau 15"
                 },
                 {
                     "pokedex_id": 404,
                     "name": "Luxio",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -58066,12 +58073,12 @@
                 {
                     "pokedex_id": 406,
                     "name": "Rozbouton",
-                    "condition":"Bonheur + Jour + 1 niveau"
+                    "condition": "Bonheur + Jour + 1 niveau"
                 },
                 {
                     "pokedex_id": 315,
                     "name": "Ros\u00e9lia",
-                    "condition":"Pierre \u00c9clat"
+                    "condition": "Pierre \u00c9clat"
                 }
             ],
             "next": null,
@@ -58344,7 +58351,7 @@
                 {
                     "pokedex_id": 408,
                     "name": "Kranidos",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -58624,7 +58631,7 @@
                 {
                     "pokedex_id": 410,
                     "name": "Dinoclier",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -58905,7 +58912,7 @@
                 {
                     "pokedex_id": 412,
                     "name": "Cheniti",
-                    "condition":"Femelle + Niveau 20"
+                    "condition": "Femelle + Niveau 20"
                 }
             ],
             "next": null,
@@ -59045,7 +59052,7 @@
                 {
                     "pokedex_id": 412,
                     "name": "Cheniti",
-                    "condition":"M\u00e2le + Niveau 20"
+                    "condition": "M\u00e2le + Niveau 20"
                 }
             ],
             "next": null,
@@ -59325,7 +59332,7 @@
                 {
                     "pokedex_id": 415,
                     "name": "Apitrini",
-                    "condition":"Femelle + Niveau 21"
+                    "condition": "Femelle + Niveau 21"
                 }
             ],
             "next": null,
@@ -59995,7 +60002,7 @@
                 {
                     "pokedex_id": 420,
                     "name": "Ceribou",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 }
             ],
             "next": null,
@@ -60281,7 +60288,7 @@
                 {
                     "pokedex_id": 422,
                     "name": "Sancoki",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -60422,7 +60429,7 @@
                 {
                     "pokedex_id": 190,
                     "name": "Capumain",
-                    "condition":"+1 Niveau avec Coup Double"
+                    "condition": "+1 Niveau avec Coup Double"
                 }
             ],
             "next": null,
@@ -60710,7 +60717,7 @@
                 {
                     "pokedex_id": 425,
                     "name": "Baudrive",
-                    "condition":"Niveau 28"
+                    "condition": "Niveau 28"
                 }
             ],
             "next": null,
@@ -61132,7 +61139,7 @@
                 {
                     "pokedex_id": 200,
                     "name": "Feufor\u00eave",
-                    "condition":"Pierre Nuit"
+                    "condition": "Pierre Nuit"
                 }
             ],
             "next": null,
@@ -61276,7 +61283,7 @@
                 {
                     "pokedex_id": 198,
                     "name": "Corn\u00e8bre",
-                    "condition":"Pierre Nuit"
+                    "condition": "Pierre Nuit"
                 }
             ],
             "next": null,
@@ -61556,7 +61563,7 @@
                 {
                     "pokedex_id": 431,
                     "name": "Chaglam",
-                    "condition":"Niveau 38"
+                    "condition": "Niveau 38"
                 }
             ],
             "next": null,
@@ -61974,7 +61981,7 @@
                 {
                     "pokedex_id": 434,
                     "name": "Moufouette",
-                    "condition":"Niveau 34"
+                    "condition": "Niveau 34"
                 }
             ],
             "next": null,
@@ -62259,7 +62266,7 @@
                 {
                     "pokedex_id": 436,
                     "name": "Arch\u00e9omire",
-                    "condition":"Niveau 33"
+                    "condition": "Niveau 33"
                 }
             ],
             "next": null,
@@ -63229,7 +63236,7 @@
                 {
                     "pokedex_id": 443,
                     "name": "Griknot",
-                    "condition":"Niveau 24"
+                    "condition": "Niveau 24"
                 }
             ],
             "next": [
@@ -63376,12 +63383,12 @@
                 {
                     "pokedex_id": 443,
                     "name": "Griknot",
-                    "condition":"Niveau 24"
+                    "condition": "Niveau 24"
                 },
                 {
                     "pokedex_id": 444,
                     "name": "Carmache",
-                    "condition":"Niveau 48"
+                    "condition": "Niveau 48"
                 }
             ],
             "next": null,
@@ -65635,7 +65642,7 @@
                 {
                     "pokedex_id": 215,
                     "name": "Farfuret",
-                    "condition":"+1 Niveau avec Griffe Rasoir / Contact d'une Griffe Rasoir (PLA)"
+                    "condition": "+1 Niveau avec Griffe Rasoir / Contact d'une Griffe Rasoir (PLA)"
                 }
             ],
             "next": null,
@@ -65779,12 +65786,12 @@
                 {
                     "pokedex_id": 81,
                     "name": "Magn\u00e9ti",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 },
                 {
                     "pokedex_id": 82,
                     "name": "Magn\u00e9ton",
-                    "condition":"+1 Niveau dans Champ Magn\u00e9tique / Pierre Foudre"
+                    "condition": "+1 Niveau dans Champ Magn\u00e9tique / Pierre Foudre"
                 }
             ],
             "next": null,
@@ -65921,7 +65928,7 @@
                 {
                     "pokedex_id": 108,
                     "name": "Excelangue",
-                    "condition":"+1 Niveau avec Roulade"
+                    "condition": "+1 Niveau avec Roulade"
                 }
             ],
             "next": null,
@@ -66065,12 +66072,12 @@
                 {
                     "pokedex_id": 111,
                     "name": "Rhinocorne",
-                    "condition":"Niveau 42"
+                    "condition": "Niveau 42"
                 },
                 {
                     "pokedex_id": 112,
                     "name": "Rhinof\u00e9ros",
-                    "condition":"Echange avec Protecteur / Contact d'un Protecteur (PLA)"
+                    "condition": "Echange avec Protecteur / Contact d'un Protecteur (PLA)"
                 }
             ],
             "next": null,
@@ -66211,7 +66218,7 @@
                 {
                     "pokedex_id": 114,
                     "name": "Saquedeneu",
-                    "condition":"+1 Niveau avec Pouvoir Antique"
+                    "condition": "+1 Niveau avec Pouvoir Antique"
                 }
             ],
             "next": null,
@@ -66347,12 +66354,12 @@
                 {
                     "pokedex_id": 239,
                     "name": "\u00c9lekid",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 },
                 {
                     "pokedex_id": 125,
                     "name": "\u00c9lektek",
-                    "condition":"Echange avec \u00c9lectriseur / Contact d'un \u00c9lectriseur (PLA)"
+                    "condition": "Echange avec \u00c9lectriseur / Contact d'un \u00c9lectriseur (PLA)"
                 }
             ],
             "next": null,
@@ -66488,12 +66495,12 @@
                 {
                     "pokedex_id": 240,
                     "name": "Magby",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 },
                 {
                     "pokedex_id": 126,
                     "name": "Magmar",
-                    "condition":"Echange avec Magmariseur / Contact d'un Magmariseur (PLA)"
+                    "condition": "Echange avec Magmariseur / Contact d'un Magmariseur (PLA)"
                 }
             ],
             "next": null,
@@ -66637,12 +66644,12 @@
                 {
                     "pokedex_id": 175,
                     "name": "Togepi",
-                    "condition":"+1 Niveau + Bonheur"
+                    "condition": "+1 Niveau + Bonheur"
                 },
                 {
                     "pokedex_id": 176,
                     "name": "Togetic",
-                    "condition":"Pierre \u00c9clat"
+                    "condition": "Pierre \u00c9clat"
                 }
             ],
             "next": null,
@@ -66787,7 +66794,7 @@
                 {
                     "pokedex_id": 193,
                     "name": "Yanma",
-                    "condition":"+1 Niveau avec Pouvoir Antique"
+                    "condition": "+1 Niveau avec Pouvoir Antique"
                 }
             ],
             "next": null,
@@ -66923,7 +66930,7 @@
                 {
                     "pokedex_id": 133,
                     "name": "\u00c9voli",
-                    "condition":"Pierre Plante"
+                    "condition": "Pierre Plante"
                 }
             ],
             "next": null,
@@ -67059,7 +67066,7 @@
                 {
                     "pokedex_id": 133,
                     "name": "\u00c9voli",
-                    "condition":"+1 Niveau Mont Lanakila / Pierre Glace (depuis EB)"
+                    "condition": "+1 Niveau Mont Lanakila / Pierre Glace (depuis EB)"
                 }
             ],
             "next": null,
@@ -67203,7 +67210,7 @@
                 {
                     "pokedex_id": 207,
                     "name": "Scorplane",
-                    "condition":"+1 Niveau avec Croc Rasoir / Contact d'un Croc Rasoir (PLA)"
+                    "condition": "+1 Niveau avec Croc Rasoir / Contact d'un Croc Rasoir (PLA)"
                 }
             ],
             "next": null,
@@ -67347,12 +67354,12 @@
                 {
                     "pokedex_id": 220,
                     "name": "Marcacrin",
-                    "condition":"Niveau 33"
+                    "condition": "Niveau 33"
                 },
                 {
                     "pokedex_id": 221,
                     "name": "Cochignon",
-                    "condition":"+1 Niveau avec Pouvoir Antique"
+                    "condition": "+1 Niveau avec Pouvoir Antique"
                 }
             ],
             "next": null,
@@ -67492,12 +67499,12 @@
                 {
                     "pokedex_id": 137,
                     "name": "Porygon",
-                    "condition":"Echange avec Am\u00e9liorator / Contact d'un Am\u00e9liorator (PLA)"
+                    "condition": "Echange avec Am\u00e9liorator / Contact d'un Am\u00e9liorator (PLA)"
                 },
                 {
                     "pokedex_id": 233,
                     "name": "Porygon2",
-                    "condition":"Echange avec CD Douteux / Contact d'un CD Douteux (PLA)"
+                    "condition": "Echange avec CD Douteux / Contact d'un CD Douteux (PLA)"
                 }
             ],
             "next": null,
@@ -67638,12 +67645,12 @@
                 {
                     "pokedex_id": 280,
                     "name": "Tarsal",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 },
                 {
                     "pokedex_id": 281,
                     "name": "Kirlia",
-                    "condition":"M\u00e2le + Pierre Aube"
+                    "condition": "M\u00e2le + Pierre Aube"
                 }
             ],
             "next": null,
@@ -67796,7 +67803,7 @@
                 {
                     "pokedex_id": 299,
                     "name": "Tarinor",
-                    "condition":"+1 Niveau dans Champ Magn\u00e9tique / Pierre Foudre (PLA)"
+                    "condition": "+1 Niveau dans Champ Magn\u00e9tique / Pierre Foudre (PLA)"
                 }
             ],
             "next": null,
@@ -67932,12 +67939,12 @@
                 {
                     "pokedex_id": 355,
                     "name": "Sk\u00e9l\u00e9nox",
-                    "condition":"Niveau 37"
+                    "condition": "Niveau 37"
                 },
                 {
                     "pokedex_id": 356,
                     "name": "T\u00e9raclope",
-                    "condition":"Echange avec Tissu Fauche / Contact d'un Tissu Fauche (PLA)"
+                    "condition": "Echange avec Tissu Fauche / Contact d'un Tissu Fauche (PLA)"
                 }
             ],
             "next": null,
@@ -68077,7 +68084,7 @@
                 {
                     "pokedex_id": 361,
                     "name": "Stalgamin",
-                    "condition":"Femelle + Pierre Aube"
+                    "condition": "Femelle + Pierre Aube"
                 }
             ],
             "next": null,
@@ -70282,7 +70289,7 @@
                 {
                     "pokedex_id": 495,
                     "name": "Vip\u00e9lierre",
-                    "condition":"Niveau 17"
+                    "condition": "Niveau 17"
                 }
             ],
             "next": [
@@ -70425,12 +70432,12 @@
                 {
                     "pokedex_id": 495,
                     "name": "Vip\u00e9lierre",
-                    "condition":"Niveau 17"
+                    "condition": "Niveau 17"
                 },
                 {
                     "pokedex_id": 496,
                     "name": "Lianaja",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -70712,7 +70719,7 @@
                 {
                     "pokedex_id": 498,
                     "name": "Gruikui",
-                    "condition":"Niveau 17"
+                    "condition": "Niveau 17"
                 }
             ],
             "next": [
@@ -70858,12 +70865,12 @@
                 {
                     "pokedex_id": 498,
                     "name": "Gruikui",
-                    "condition":"Niveau 17"
+                    "condition": "Niveau 17"
                 },
                 {
                     "pokedex_id": 499,
                     "name": "Grotichon",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -71145,7 +71152,7 @@
                 {
                     "pokedex_id": 501,
                     "name": "Moustillon",
-                    "condition":"Niveau 17"
+                    "condition": "Niveau 17"
                 }
             ],
             "next": [
@@ -71292,12 +71299,12 @@
                 {
                     "pokedex_id": 501,
                     "name": "Moustillon",
-                    "condition":"Niveau 17"
+                    "condition": "Niveau 17"
                 },
                 {
                     "pokedex_id": 502,
                     "name": "Mateloutre",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -71871,7 +71878,7 @@
                 {
                     "pokedex_id": 506,
                     "name": "Ponchiot",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -72017,12 +72024,12 @@
                 {
                     "pokedex_id": 506,
                     "name": "Ponchiot",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 507,
                     "name": "Ponchien",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 }
             ],
             "next": null,
@@ -72302,7 +72309,7 @@
                 {
                     "pokedex_id": 509,
                     "name": "Chacripan",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 }
             ],
             "next": null,
@@ -72574,7 +72581,7 @@
                 {
                     "pokedex_id": 511,
                     "name": "Feuillajou",
-                    "condition":"Pierre Plante"
+                    "condition": "Pierre Plante"
                 }
             ],
             "next": null,
@@ -72846,7 +72853,7 @@
                 {
                     "pokedex_id": 513,
                     "name": "Flamajou",
-                    "condition":"Pierre Feu"
+                    "condition": "Pierre Feu"
                 }
             ],
             "next": null,
@@ -73118,7 +73125,7 @@
                 {
                     "pokedex_id": 515,
                     "name": "Flotajou",
-                    "condition":"Pierre Eau"
+                    "condition": "Pierre Eau"
                 }
             ],
             "next": null,
@@ -73398,7 +73405,7 @@
                 {
                     "pokedex_id": 517,
                     "name": "Munna",
-                    "condition":"Pierre Lune"
+                    "condition": "Pierre Lune"
                 }
             ],
             "next": null,
@@ -73691,7 +73698,7 @@
                 {
                     "pokedex_id": 519,
                     "name": "Poichigeon",
-                    "condition":"Niveau 21"
+                    "condition": "Niveau 21"
                 }
             ],
             "next": [
@@ -73841,12 +73848,12 @@
                 {
                     "pokedex_id": 519,
                     "name": "Poichigeon",
-                    "condition":"Niveau 21"
+                    "condition": "Niveau 21"
                 },
                 {
                     "pokedex_id": 520,
                     "name": "Colombeau",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 }
             ],
             "next": null,
@@ -74126,7 +74133,7 @@
                 {
                     "pokedex_id": 522,
                     "name": "Z\u00e9bibron",
-                    "condition":"Niveau 27"
+                    "condition": "Niveau 27"
                 }
             ],
             "next": null,
@@ -74411,7 +74418,7 @@
                 {
                     "pokedex_id": 524,
                     "name": "Nodulithe",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 }
             ],
             "next": [
@@ -74557,12 +74564,12 @@
                 {
                     "pokedex_id": 524,
                     "name": "Nodulithe",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 },
                 {
                     "pokedex_id": 525,
                     "name": "G\u00e9olithe",
-                    "condition":"Echange"
+                    "condition": "Echange"
                 }
             ],
             "next": null,
@@ -74851,7 +74858,7 @@
                 {
                     "pokedex_id": 527,
                     "name": "Chovsourir",
-                    "condition":"Bonheur"
+                    "condition": "Bonheur"
                 }
             ],
             "next": null,
@@ -75136,7 +75143,7 @@
                 {
                     "pokedex_id": 529,
                     "name": "Rototaupe",
-                    "condition":"Niveau 31"
+                    "condition": "Niveau 31"
                 }
             ],
             "next": null,
@@ -75551,7 +75558,7 @@
                 {
                     "pokedex_id": 532,
                     "name": "Charpenti",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 }
             ],
             "next": [
@@ -75697,12 +75704,12 @@
                 {
                     "pokedex_id": 532,
                     "name": "Charpenti",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 },
                 {
                     "pokedex_id": 533,
                     "name": "Ouvrifier",
-                    "condition":"Echange"
+                    "condition": "Echange"
                 }
             ],
             "next": null,
@@ -75991,7 +75998,7 @@
                 {
                     "pokedex_id": 535,
                     "name": "Tritonde",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 }
             ],
             "next": [
@@ -76141,12 +76148,12 @@
                 {
                     "pokedex_id": 535,
                     "name": "Tritonde",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 },
                 {
                     "pokedex_id": 536,
                     "name": "Batracn\u00e9",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -76699,7 +76706,7 @@
                 {
                     "pokedex_id": 540,
                     "name": "Larvayette",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 }
             ],
             "next": [
@@ -76849,12 +76856,12 @@
                 {
                     "pokedex_id": 540,
                     "name": "Larvayette",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 },
                 {
                     "pokedex_id": 541,
                     "name": "Couverdure",
-                    "condition":"Bonheur"
+                    "condition": "Bonheur"
                 }
             ],
             "next": null,
@@ -77147,7 +77154,7 @@
                 {
                     "pokedex_id": 543,
                     "name": "Venipatte",
-                    "condition":"Niveau 22"
+                    "condition": "Niveau 22"
                 }
             ],
             "next": [
@@ -77595,7 +77602,7 @@
                 {
                     "pokedex_id": 546,
                     "name": "Doudouvet",
-                    "condition":"Pierre Soleil"
+                    "condition": "Pierre Soleil"
                 }
             ],
             "next": null,
@@ -77881,7 +77888,7 @@
                 {
                     "pokedex_id": 548,
                     "name": "Chlorobule",
-                    "condition":"Pierre Soleil"
+                    "condition": "Pierre Soleil"
                 }
             ],
             "next": null,
@@ -78323,7 +78330,7 @@
                 {
                     "pokedex_id": 551,
                     "name": "Masca\u00efman",
-                    "condition":"Niveau 29"
+                    "condition": "Niveau 29"
                 }
             ],
             "next": [
@@ -78473,12 +78480,12 @@
                 {
                     "pokedex_id": 551,
                     "name": "Masca\u00efman",
-                    "condition":"Niveau 29"
+                    "condition": "Niveau 29"
                 },
                 {
                     "pokedex_id": 552,
                     "name": "Escroco",
-                    "condition":"Niveau 40"
+                    "condition": "Niveau 40"
                 }
             ],
             "next": null,
@@ -78759,7 +78766,7 @@
                 {
                     "pokedex_id": 554,
                     "name": "Darumarond",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 }
             ],
             "next": null,
@@ -79187,7 +79194,7 @@
                 {
                     "pokedex_id": 557,
                     "name": "Crabicoque",
-                    "condition":"Niveau 34"
+                    "condition": "Niveau 34"
                 }
             ],
             "next": null,
@@ -79477,10 +79484,10 @@
                 {
                     "pokedex_id": 559,
                     "name": "Baggiguane",
-                    "condition":"Niveau 39"
+                    "condition": "Niveau 39"
                 }
             ],
-            "next":null,
+            "next": null,
             "mega": null
         },
         "next": null,
@@ -79887,7 +79894,7 @@
                 {
                     "pokedex_id": 562,
                     "name": "Tutafeh",
-                    "condition":"Niveau 34"
+                    "condition": "Niveau 34"
                 }
             ],
             "next": null,
@@ -80177,7 +80184,7 @@
                 {
                     "pokedex_id": 564,
                     "name": "Carapagos",
-                    "condition":"Niveau 37"
+                    "condition": "Niveau 37"
                 }
             ],
             "next": null,
@@ -80451,7 +80458,7 @@
                 {
                     "pokedex_id": 566,
                     "name": "Ark\u00e9apti",
-                    "condition":"Niveau 37"
+                    "condition": "Niveau 37"
                 }
             ],
             "next": null,
@@ -80735,7 +80742,7 @@
                 {
                     "pokedex_id": 568,
                     "name": "Miamiasme",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -81008,7 +81015,7 @@
                 {
                     "pokedex_id": 570,
                     "name": "Zorua",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -81297,7 +81304,7 @@
                 {
                     "pokedex_id": 572,
                     "name": "Chinchidou",
-                    "condition":"Pierre \u00c9clat"
+                    "condition": "Pierre \u00c9clat"
                 }
             ],
             "next": null,
@@ -81582,7 +81589,7 @@
                 {
                     "pokedex_id": 574,
                     "name": "Scrutella",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 }
             ],
             "next": [
@@ -81728,12 +81735,12 @@
                 {
                     "pokedex_id": 574,
                     "name": "Scrutella",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 },
                 {
                     "pokedex_id": 575,
                     "name": "Mesm\u00e9rella",
-                    "condition":"Niveau 41"
+                    "condition": "Niveau 41"
                 }
             ],
             "next": null,
@@ -82018,7 +82025,7 @@
                 {
                     "pokedex_id": 577,
                     "name": "Nucl\u00e9os",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 }
             ],
             "next": [
@@ -82164,12 +82171,12 @@
                 {
                     "pokedex_id": 577,
                     "name": "Nucl\u00e9os",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 },
                 {
                     "pokedex_id": 578,
                     "name": "M\u00e9ios",
-                    "condition":"Niveau 41"
+                    "condition": "Niveau 41"
                 }
             ],
             "next": null,
@@ -82458,7 +82465,7 @@
                 {
                     "pokedex_id": 580,
                     "name": "Couaneton",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 }
             ],
             "next": null,
@@ -82744,7 +82751,7 @@
                 {
                     "pokedex_id": 582,
                     "name": "Sorb\u00e9b\u00e9",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 }
             ],
             "next": [
@@ -82890,12 +82897,12 @@
                 {
                     "pokedex_id": 582,
                     "name": "Sorb\u00e9b\u00e9",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 },
                 {
                     "pokedex_id": 583,
                     "name": "Sorboul",
-                    "condition":"Niveau 47"
+                    "condition": "Niveau 47"
                 }
             ],
             "next": null,
@@ -83183,7 +83190,7 @@
                 {
                     "pokedex_id": 585,
                     "name": "Vivaldaim",
-                    "condition":"Niveau 34"
+                    "condition": "Niveau 34"
                 }
             ],
             "next": null,
@@ -83877,7 +83884,7 @@
                 {
                     "pokedex_id": 590,
                     "name": "Trompignon",
-                    "condition":"Niveau 39"
+                    "condition": "Niveau 39"
                 }
             ],
             "next": null,
@@ -84165,7 +84172,7 @@
                 {
                     "pokedex_id": 592,
                     "name": "Viskuse",
-                    "condition":"Niveau 40"
+                    "condition": "Niveau 40"
                 }
             ],
             "next": null,
@@ -84584,7 +84591,7 @@
                 {
                     "pokedex_id": 595,
                     "name": "Statitik",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -85292,7 +85299,7 @@
                 {
                     "pokedex_id": 600,
                     "name": "Clic",
-                    "condition":"Niveau 49"
+                    "condition": "Niveau 49"
                 }
             ],
             "next": null,
@@ -85701,7 +85708,7 @@
                 {
                     "pokedex_id": 603,
                     "name": "Lamp\u00e9roie",
-                    "condition":"Pierre Foudre"
+                    "condition": "Pierre Foudre"
                 }
             ],
             "next": null,
@@ -86433,7 +86440,7 @@
                 {
                     "pokedex_id": 608,
                     "name": "M\u00e9lancolux",
-                    "condition":"Pierre Nuit"
+                    "condition": "Pierre Nuit"
                 }
             ],
             "next": null,
@@ -86871,7 +86878,7 @@
                 {
                     "pokedex_id": 611,
                     "name": "Incisache",
-                    "condition":"Niveau 48"
+                    "condition": "Niveau 48"
                 }
             ],
             "next": null,
@@ -92123,7 +92130,7 @@
                 {
                     "pokedex_id": 650,
                     "name": "Marisson",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -92269,12 +92276,12 @@
                 {
                     "pokedex_id": 650,
                     "name": "Marisson",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 651,
                     "name": "Bogu\u00e9risse",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -92551,7 +92558,7 @@
                 {
                     "pokedex_id": 653,
                     "name": "Feunnec",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -92697,12 +92704,12 @@
                 {
                     "pokedex_id": 653,
                     "name": "Feunnec",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 654,
                     "name": "Roussil",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -92979,7 +92986,7 @@
                 {
                     "pokedex_id": 656,
                     "name": "Grenousse",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -93129,12 +93136,12 @@
                 {
                     "pokedex_id": 656,
                     "name": "Grenousse",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 657,
                     "name": "Cro\u00e0poral",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -93418,7 +93425,7 @@
                 {
                     "pokedex_id": 659,
                     "name": "Sapereau",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 }
             ],
             "next": null,
@@ -93703,7 +93710,7 @@
                 {
                     "pokedex_id": 661,
                     "name": "Passerouge",
-                    "condition":"Niveau 17"
+                    "condition": "Niveau 17"
                 }
             ],
             "next": [
@@ -93849,12 +93856,12 @@
                 {
                     "pokedex_id": 661,
                     "name": "Passerouge",
-                    "condition":"Niveau 17"
+                    "condition": "Niveau 17"
                 },
                 {
                     "pokedex_id": 662,
                     "name": "Braisillon",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 }
             ],
             "next": null,
@@ -94135,7 +94142,7 @@
                 {
                     "pokedex_id": 664,
                     "name": "L\u00e9pidonille",
-                    "condition":"Niveau 9"
+                    "condition": "Niveau 9"
                 }
             ],
             "next": [
@@ -94285,12 +94292,12 @@
                 {
                     "pokedex_id": 664,
                     "name": "L\u00e9pidonille",
-                    "condition":"Niveau 9"
+                    "condition": "Niveau 9"
                 },
                 {
                     "pokedex_id": 665,
                     "name": "P\u00e9r\u00e9grain",
-                    "condition":"Niveau 12"
+                    "condition": "Niveau 12"
                 }
             ],
             "next": null,
@@ -94578,7 +94585,7 @@
                 {
                     "pokedex_id": 667,
                     "name": "H\u00e9lionceau",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 }
             ],
             "next": null,
@@ -94855,7 +94862,7 @@
                 {
                     "pokedex_id": 669,
                     "name": "Flab\u00e9b\u00e9",
-                    "condition":"Niveau 19"
+                    "condition": "Niveau 19"
                 }
             ],
             "next": [
@@ -94997,12 +95004,12 @@
                 {
                     "pokedex_id": 669,
                     "name": "Flab\u00e9b\u00e9",
-                    "condition":"Niveau 19"
+                    "condition": "Niveau 19"
                 },
                 {
                     "pokedex_id": 670,
                     "name": "Floette",
-                    "condition":"Pierre \u00c9clat"
+                    "condition": "Pierre \u00c9clat"
                 }
             ],
             "next": null,
@@ -95274,7 +95281,7 @@
                 {
                     "pokedex_id": 672,
                     "name": "Cabriolaine",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 }
             ],
             "next": null,
@@ -95559,7 +95566,7 @@
                 {
                     "pokedex_id": 674,
                     "name": "Pandespi\u00e8gle",
-                    "condition":"Niveau 32 + Pokemon type T\u00e9n\u00e8bres dans l'\u00e9quipe"
+                    "condition": "Niveau 32 + Pokemon type T\u00e9n\u00e8bres dans l'\u00e9quipe"
                 }
             ],
             "next": null,
@@ -95962,7 +95969,7 @@
                 {
                     "pokedex_id": 677,
                     "name": "Psystigri",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 }
             ],
             "next": null,
@@ -96239,7 +96246,7 @@
                 {
                     "pokedex_id": 679,
                     "name": "Monorpale",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 }
             ],
             "next": [
@@ -96381,12 +96388,12 @@
                 {
                     "pokedex_id": 679,
                     "name": "Monorpale",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 },
                 {
                     "pokedex_id": 680,
                     "name": "Dimocl\u00e8s",
-                    "condition":"Pierre Nuit"
+                    "condition": "Pierre Nuit"
                 }
             ],
             "next": null,
@@ -96658,7 +96665,7 @@
                 {
                     "pokedex_id": 682,
                     "name": "Fluvetin",
-                    "condition":"Echange avec Sachet Senteur"
+                    "condition": "Echange avec Sachet Senteur"
                 }
             ],
             "next": null,
@@ -96930,7 +96937,7 @@
                 {
                     "pokedex_id": 684,
                     "name": "Sucroquin",
-                    "condition":"Echange avec Chantibonbon"
+                    "condition": "Echange avec Chantibonbon"
                 }
             ],
             "next": null,
@@ -97219,7 +97226,7 @@
                 {
                     "pokedex_id": 686,
                     "name": "Sepiatop",
-                    "condition":"Niveau 30 en retournant la console de jeu"
+                    "condition": "Niveau 30 en retournant la console de jeu"
                 }
             ],
             "next": null,
@@ -97508,7 +97515,7 @@
                 {
                     "pokedex_id": 688,
                     "name": "Opermine",
-                    "condition":"Niveau 39"
+                    "condition": "Niveau 39"
                 }
             ],
             "next": null,
@@ -97797,7 +97804,7 @@
                 {
                     "pokedex_id": 690,
                     "name": "Venalgue",
-                    "condition":"Niveau 48"
+                    "condition": "Niveau 48"
                 }
             ],
             "next": null,
@@ -98063,7 +98070,7 @@
                 {
                     "pokedex_id": 692,
                     "name": "Flingouste",
-                    "condition":"Niveau 37"
+                    "condition": "Niveau 37"
                 }
             ],
             "next": null,
@@ -98353,7 +98360,7 @@
                 {
                     "pokedex_id": 694,
                     "name": "Galvaran",
-                    "condition":"Pierre Soleil"
+                    "condition": "Pierre Soleil"
                 }
             ],
             "next": null,
@@ -98635,7 +98642,7 @@
                 {
                     "pokedex_id": 696,
                     "name": "Ptyranidur",
-                    "condition":"Niveau 39 durant la journ\u00e9e"
+                    "condition": "Niveau 39 durant la journ\u00e9e"
                 }
             ],
             "next": null,
@@ -98916,7 +98923,7 @@
                 {
                     "pokedex_id": 698,
                     "name": "Amagara",
-                    "condition":"Niveau 39 pendant la nuit"
+                    "condition": "Niveau 39 pendant la nuit"
                 }
             ],
             "next": null,
@@ -99052,7 +99059,7 @@
                 {
                     "pokedex_id": 133,
                     "name": "\u00c9voli",
-                    "condition":"Bonheur + Nuit + 1 niveau + aucune capacit\u00e9 F\u00e9e"
+                    "condition": "Bonheur + Nuit + 1 niveau + aucune capacit\u00e9 F\u00e9e"
                 }
             ],
             "next": null,
@@ -99735,7 +99742,7 @@
                 {
                     "pokedex_id": 704,
                     "name": "Mucuscule",
-                    "condition":"Niveau 40"
+                    "condition": "Niveau 40"
                 }
             ],
             "next": [
@@ -99890,12 +99897,12 @@
                 {
                     "pokedex_id": 704,
                     "name": "Mucuscule",
-                    "condition":"Niveau 40"
+                    "condition": "Niveau 40"
                 },
                 {
                     "pokedex_id": 705,
                     "name": "Colimucus",
-                    "condition":"Niveau 50 sous la pluie"
+                    "condition": "Niveau 50 sous la pluie"
                 }
             ],
             "next": null,
@@ -100323,7 +100330,7 @@
                 {
                     "pokedex_id": 708,
                     "name": "Broc\u00e9l\u00f4me",
-                    "condition":"Echange"
+                    "condition": "Echange"
                 }
             ],
             "next": null,
@@ -100612,7 +100619,7 @@
                 {
                     "pokedex_id": 710,
                     "name": "Pitrouille",
-                    "condition":"Echange"
+                    "condition": "Echange"
                 }
             ],
             "next": null,
@@ -100898,7 +100905,7 @@
                 {
                     "pokedex_id": 712,
                     "name": "Grela\u00e7on",
-                    "condition":"Niveau 37"
+                    "condition": "Niveau 37"
                 }
             ],
             "next": null,
@@ -101197,7 +101204,7 @@
                 {
                     "pokedex_id": 714,
                     "name": "Sonistrelle",
-                    "condition":"Niveau 48"
+                    "condition": "Niveau 48"
                 }
             ],
             "next": null,
@@ -102209,7 +102216,7 @@
                 {
                     "pokedex_id": 722,
                     "name": "Brindibou",
-                    "condition":"Niveau 17"
+                    "condition": "Niveau 17"
                 }
             ],
             "next": [
@@ -102355,12 +102362,12 @@
                 {
                     "pokedex_id": 722,
                     "name": "Brindibou",
-                    "condition":"Niveau 17"
+                    "condition": "Niveau 17"
                 },
                 {
                     "pokedex_id": 723,
                     "name": "Effl\u00e8che",
-                    "condition":"Niveau 34 / Niveau 36 (PLA uniquement)"
+                    "condition": "Niveau 34 / Niveau 36 (PLA uniquement)"
                 }
             ],
             "next": null,
@@ -102646,7 +102653,7 @@
                 {
                     "pokedex_id": 725,
                     "name": "Flamiaou",
-                    "condition":"Niveau 17"
+                    "condition": "Niveau 17"
                 }
             ],
             "next": [
@@ -102792,12 +102799,12 @@
                 {
                     "pokedex_id": 725,
                     "name": "Flamiaou",
-                    "condition":"Niveau 17"
+                    "condition": "Niveau 17"
                 },
                 {
                     "pokedex_id": 726,
                     "name": "Matoufeu",
-                    "condition":"Niveau 34"
+                    "condition": "Niveau 34"
                 }
             ],
             "next": null,
@@ -103075,7 +103082,7 @@
                 {
                     "pokedex_id": 728,
                     "name": "Otaquin",
-                    "condition":"Niveau 17"
+                    "condition": "Niveau 17"
                 }
             ],
             "next": [
@@ -103222,12 +103229,12 @@
                 {
                     "pokedex_id": 728,
                     "name": "Otaquin",
-                    "condition":"Niveau 17"
+                    "condition": "Niveau 17"
                 },
                 {
                     "pokedex_id": 729,
                     "name": "Otarlette",
-                    "condition":"Niveau 34"
+                    "condition": "Niveau 34"
                 }
             ],
             "next": null,
@@ -103521,7 +103528,7 @@
                 {
                     "pokedex_id": 731,
                     "name": "Picassaut",
-                    "condition":"Niveau 14"
+                    "condition": "Niveau 14"
                 }
             ],
             "next": [
@@ -103671,12 +103678,12 @@
                 {
                     "pokedex_id": 732,
                     "name": "Picassaut",
-                    "condition":"Niveau 14"
+                    "condition": "Niveau 14"
                 },
                 {
                     "pokedex_id": 733,
                     "name": "Piclairon",
-                    "condition":"Niveau 28"
+                    "condition": "Niveau 28"
                 }
             ],
             "next": null,
@@ -103956,7 +103963,7 @@
                 {
                     "pokedex_id": 734,
                     "name": "Manglouton",
-                    "condition":"Niveau 20 la journ\u00e9e"
+                    "condition": "Niveau 20 la journ\u00e9e"
                 }
             ],
             "next": null,
@@ -104229,7 +104236,7 @@
                 {
                     "pokedex_id": 736,
                     "name": "Larvibule",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 }
             ],
             "next": [
@@ -104371,12 +104378,12 @@
                 {
                     "pokedex_id": 736,
                     "name": "Larvibule",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 },
                 {
                     "pokedex_id": 737,
                     "name": "Chrysapile",
-                    "condition":"+1 Niveau au Grand Canyon de Poni ou Mont Ardent (SL/USUL) / Pierre Foudre (depuis EB)"
+                    "condition": "+1 Niveau au Grand Canyon de Poni ou Mont Ardent (SL/USUL) / Pierre Foudre (depuis EB)"
                 }
             ],
             "next": null,
@@ -104660,7 +104667,7 @@
                 {
                     "pokedex_id": 739,
                     "name": "Crabagarre",
-                    "condition":"+1 Niveau Mont Lanakila / Pierre Glace (depuis EV)"
+                    "condition": "+1 Niveau Mont Lanakila / Pierre Glace (depuis EV)"
                 }
             ],
             "next": null,
@@ -105075,7 +105082,7 @@
                 {
                     "pokedex_id": 742,
                     "name": "Bombydou",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 }
             ],
             "next": null,
@@ -105360,7 +105367,7 @@
                 {
                     "pokedex_id": 744,
                     "name": "Rocabot",
-                    "condition":"Niveau 25 (forme en fonction de son talent, jour ou nuit)"
+                    "condition": "Niveau 25 (forme en fonction de son talent, jour ou nuit)"
                 }
             ],
             "next": null,
@@ -105770,7 +105777,7 @@
                 {
                     "pokedex_id": 747,
                     "name": "Vorast\u00e8rie",
-                    "condition":"Niveau 38"
+                    "condition": "Niveau 38"
                 }
             ],
             "next": null,
@@ -106050,7 +106057,7 @@
                 {
                     "pokedex_id": 749,
                     "name": "Tiboudet",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -106331,7 +106338,7 @@
                 {
                     "pokedex_id": 751,
                     "name": "Araqua",
-                    "condition":"Niveau 22"
+                    "condition": "Niveau 22"
                 }
             ],
             "next": null,
@@ -106604,7 +106611,7 @@
                 {
                     "pokedex_id": 753,
                     "name": "Mimantis",
-                    "condition":"Niveau 34 en journ\u00e9e"
+                    "condition": "Niveau 34 en journ\u00e9e"
                 }
             ],
             "next": null,
@@ -106892,7 +106899,7 @@
                 {
                     "pokedex_id": 755,
                     "name": "Spododo",
-                    "condition":"Niveau 24"
+                    "condition": "Niveau 24"
                 }
             ],
             "next": null,
@@ -107173,7 +107180,7 @@
                 {
                     "pokedex_id": 757,
                     "name": "Tritox",
-                    "condition":"Niveau 33 seulement si femelle"
+                    "condition": "Niveau 33 seulement si femelle"
                 }
             ],
             "next": null,
@@ -107462,7 +107469,7 @@
                 {
                     "pokedex_id": 759,
                     "name": "Nounourson",
-                    "condition":"Niveau 27"
+                    "condition": "Niveau 27"
                 }
             ],
             "next": null,
@@ -107747,7 +107754,7 @@
                 {
                     "pokedex_id": 761,
                     "name": "Croquine",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 }
             ],
             "next": [
@@ -107893,12 +107900,12 @@
                 {
                     "pokedex_id": 761,
                     "name": "Croquine",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 },
                 {
                     "pokedex_id": 762,
                     "name": "Candine",
-                    "condition":"+1 Niveau avec Ecrasement"
+                    "condition": "+1 Niveau avec Ecrasement"
                 }
             ],
             "next": null,
@@ -108561,7 +108568,7 @@
                 {
                     "pokedex_id": 767,
                     "name": "Sovkipou",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -108842,7 +108849,7 @@
                 {
                     "pokedex_id": 769,
                     "name": "Bacabouh",
-                    "condition":"Niveau 42"
+                    "condition": "Niveau 42"
                 }
             ],
             "next": null,
@@ -109227,7 +109234,7 @@
                 {
                     "pokedex_id": 772,
                     "name": "Type:0",
-                    "condition":"+1 Niveau + Bonheur Max"
+                    "condition": "+1 Niveau + Bonheur Max"
                 }
             ],
             "next": null,
@@ -110536,7 +110543,7 @@
                 {
                     "pokedex_id": 782,
                     "name": "B\u00e9b\u00e9caille",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 }
             ],
             "next": [
@@ -110686,12 +110693,12 @@
                 {
                     "pokedex_id": 782,
                     "name": "B\u00e9b\u00e9caille",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 },
                 {
                     "pokedex_id": 783,
                     "name": "\u00c9ca\u00efd",
-                    "condition":"Niveau 45"
+                    "condition": "Niveau 45"
                 }
             ],
             "next": null,
@@ -111460,7 +111467,7 @@
                 {
                     "pokedex_id": 789,
                     "name": "Cosmog",
-                    "condition":"Niveau 43"
+                    "condition": "Niveau 43"
                 }
             ],
             "next": [
@@ -111601,11 +111608,13 @@
             "pre": [
                 {
                     "pokedex_id": 789,
-                    "name": "Cosmog"
+                    "name": "Cosmog",
+                    "condition": "Niveau 43"
                 },
                 {
                     "pokedex_id": 790,
-                    "name": "Cosmovum"
+                    "name": "Cosmovum",
+                    "condition": "Niveau 53"
                 }
             ],
             "next": null,
@@ -111736,12 +111745,12 @@
                 {
                     "pokedex_id": 789,
                     "name": "Cosmog",
-                    "condition":"Niveau 43"
+                    "condition": "Niveau 43"
                 },
                 {
                     "pokedex_id": 790,
                     "name": "Cosmovum",
-                    "condition":"Niveau 53"
+                    "condition": "Niveau 53"
                 }
             ],
             "next": null,
@@ -113201,7 +113210,7 @@
                 {
                     "pokedex_id": 803,
                     "name": "V\u00e9mini",
-                    "condition":"+1 Niveau avec Dracochoc"
+                    "condition": "+1 Niveau avec Dracochoc"
                 }
             ],
             "next": null,
@@ -113817,7 +113826,7 @@
                 {
                     "pokedex_id": 808,
                     "name": "Meltan",
-                    "condition":"400 Bonbons Meltan (POGO)"
+                    "condition": "400 Bonbons Meltan (POGO)"
                 }
             ],
             "next": null,
@@ -114090,7 +114099,7 @@
                 {
                     "pokedex_id": 810,
                     "name": "Ouistempo",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -114236,12 +114245,12 @@
                 {
                     "pokedex_id": 810,
                     "name": "Ouistempo",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 811,
                     "name": "Badabouin",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 }
             ],
             "next": null,
@@ -114520,7 +114529,7 @@
                 {
                     "pokedex_id": 813,
                     "name": "Flambino",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -114666,12 +114675,12 @@
                 {
                     "pokedex_id": 813,
                     "name": "Flambino",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 814,
                     "name": "Lapyro",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 }
             ],
             "next": null,
@@ -114950,7 +114959,7 @@
                 {
                     "pokedex_id": 816,
                     "name": "Larm\u00e9l\u00e9on",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -115096,12 +115105,12 @@
                 {
                     "pokedex_id": 816,
                     "name": "Larm\u00e9l\u00e9on",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 817,
                     "name": "Arrozard",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 }
             ],
             "next": null,
@@ -115374,7 +115383,7 @@
                 {
                     "pokedex_id": 819,
                     "name": "Rongourmand",
-                    "condition":"Niveau 24"
+                    "condition": "Niveau 24"
                 }
             ],
             "next": null,
@@ -115659,7 +115668,7 @@
                 {
                     "pokedex_id": 821,
                     "name": "Minisange",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 }
             ],
             "next": [
@@ -115812,12 +115821,12 @@
                 {
                     "pokedex_id": 821,
                     "name": "Minisange",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 },
                 {
                     "pokedex_id": 822,
                     "name": "Bleuseille",
-                    "condition":"Niveau 38"
+                    "condition": "Niveau 38"
                 }
             ],
             "next": null,
@@ -116106,7 +116115,7 @@
                 {
                     "pokedex_id": 824,
                     "name": "Larvadar",
-                    "condition":"Niveau 10"
+                    "condition": "Niveau 10"
                 }
             ],
             "next": [
@@ -116259,12 +116268,12 @@
                 {
                     "pokedex_id": 824,
                     "name": "Larvadar",
-                    "condition":"Niveau 10"
+                    "condition": "Niveau 10"
                 },
                 {
                     "pokedex_id": 825,
                     "name": "Col\u00e9od\u00f3me",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -116544,7 +116553,7 @@
                 {
                     "pokedex_id": 827,
                     "name": "Goupilou",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 }
             ],
             "next": null,
@@ -116824,7 +116833,7 @@
                 {
                     "pokedex_id": 829,
                     "name": "Tournicoton",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 }
             ],
             "next": null,
@@ -117104,7 +117113,7 @@
                 {
                     "pokedex_id": 831,
                     "name": "Moumouton",
-                    "condition":"Niveau 24"
+                    "condition": "Niveau 24"
                 }
             ],
             "next": null,
@@ -117392,7 +117401,7 @@
                 {
                     "pokedex_id": 833,
                     "name": "Kh\u00e9locrok",
-                    "condition":"Niveau 22"
+                    "condition": "Niveau 22"
                 }
             ],
             "next": null,
@@ -117665,7 +117674,7 @@
                 {
                     "pokedex_id": 835,
                     "name": "Voltoutou",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 }
             ],
             "next": null,
@@ -117954,7 +117963,7 @@
                 {
                     "pokedex_id": 837,
                     "name": "Charbi",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 }
             ],
             "next": [
@@ -118107,12 +118116,12 @@
                 {
                     "pokedex_id": 837,
                     "name": "Charbi",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 },
                 {
                     "pokedex_id": 838,
                     "name": "Wagomine",
-                    "condition":"Niveau 34"
+                    "condition": "Niveau 34"
                 }
             ],
             "next": null,
@@ -118414,7 +118423,7 @@
                 {
                     "pokedex_id": 840,
                     "name": "Verpom",
-                    "condition":"Avec une Pomme Acidul\u00e9e"
+                    "condition": "Avec une Pomme Acidul\u00e9e"
                 }
             ],
             "next": null,
@@ -118562,7 +118571,7 @@
                 {
                     "pokedex_id": 840,
                     "name": "Verpom",
-                    "condition":"Avec une Pomme Sucr\u00e9e"
+                    "condition": "Avec une Pomme Sucr\u00e9e"
                 }
             ],
             "next": null,
@@ -118847,7 +118856,7 @@
                 {
                     "pokedex_id": 843,
                     "name": "Dunaja",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -119247,7 +119256,7 @@
                 {
                     "pokedex_id": 846,
                     "name": "Embrochet",
-                    "condition":"Niveau 26"
+                    "condition": "Niveau 26"
                 }
             ],
             "next": null,
@@ -119536,7 +119545,7 @@
                 {
                     "pokedex_id": 848,
                     "name": "Toxizap",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -119825,7 +119834,7 @@
                 {
                     "pokedex_id": 850,
                     "name": "Grillepattes",
-                    "condition":"Niveau 28"
+                    "condition": "Niveau 28"
                 }
             ],
             "next": null,
@@ -120098,7 +120107,7 @@
                 {
                     "pokedex_id": 852,
                     "name": "Poulpaf",
-                    "condition":"+1 Niveau avec Provoc"
+                    "condition": "+1 Niveau avec Provoc"
                 }
             ],
             "next": null,
@@ -120369,7 +120378,7 @@
                 {
                     "pokedex_id": 854,
                     "name": "Th\u00e9ffroi",
-                    "condition":"Avec une Th\u00e9i\u00e8re F\u00eal\u00e9e ou une Th\u00e9i\u00e8re \u00c9br\u00e9ch\u00e9e"
+                    "condition": "Avec une Th\u00e9i\u00e8re F\u00eal\u00e9e ou une Th\u00e9i\u00e8re \u00c9br\u00e9ch\u00e9e"
                 }
             ],
             "next": null,
@@ -120652,7 +120661,7 @@
                 {
                     "pokedex_id": 856,
                     "name": "Bibichut",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 }
             ],
             "next": [
@@ -120805,12 +120814,12 @@
                 {
                     "pokedex_id": 856,
                     "name": "Bibichut",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 },
                 {
                     "pokedex_id": 857,
                     "name": "Chapotus",
-                    "condition":"Niveau 42"
+                    "condition": "Niveau 42"
                 }
             ],
             "next": null,
@@ -121104,7 +121113,7 @@
                 {
                     "pokedex_id": 859,
                     "name": "Grimalin",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 }
             ],
             "next": [
@@ -121258,12 +121267,12 @@
                 {
                     "pokedex_id": 859,
                     "name": "Grimalin",
-                    "condition":"Niveau 32"
+                    "condition": "Niveau 32"
                 },
                 {
                     "pokedex_id": 860,
                     "name": "Fourbelin",
-                    "condition":"Niveau 42"
+                    "condition": "Niveau 42"
                 }
             ],
             "next": null,
@@ -121408,12 +121417,12 @@
                 {
                     "pokedex_id": 263,
                     "name": "Zigzaton de Galar",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 },
                 {
                     "pokedex_id": 264,
                     "name": "Lin\u00e9on de Galar",
-                    "condition":"Niveau 35 + Nuit"
+                    "condition": "Niveau 35 + Nuit"
                 }
             ],
             "next": null,
@@ -121553,7 +121562,7 @@
                 {
                     "pokedex_id": 52,
                     "name": "Miaouss de Galar",
-                    "condition":"Niveau 28"
+                    "condition": "Niveau 28"
                 }
             ],
             "next": null,
@@ -121689,7 +121698,7 @@
                 {
                     "pokedex_id": 222,
                     "name": "Corayon de Galar",
-                    "condition":"Niveau 38"
+                    "condition": "Niveau 38"
                 }
             ],
             "next": null,
@@ -121826,7 +121835,7 @@
                 {
                     "pokedex_id": 83,
                     "name": "Canarticho de Galar",
-                    "condition":"Infliger 3 coups critiques dans un même combat"
+                    "condition": "Infliger 3 coups critiques dans un même combat"
                 }
             ],
             "next": null,
@@ -121971,7 +121980,7 @@
                 {
                     "pokedex_id": 122,
                     "name": "M.Mime de Galar",
-                    "condition":"Niveau 42"
+                    "condition": "Niveau 42"
                 }
             ],
             "next": null,
@@ -122107,7 +122116,7 @@
                 {
                     "pokedex_id": 562,
                     "name": "Tutafeh de Galar",
-                    "condition":"Perdre 49 PV ou plus + marcher sous la grande arche de pierres de la Fosse des Sables"
+                    "condition": "Perdre 49 PV ou plus + marcher sous la grande arche de pierres de la Fosse des Sables"
                 }
             ],
             "next": null,
@@ -122384,7 +122393,7 @@
                 {
                     "pokedex_id": 868,
                     "name": "Cr\u00e8my",
-                    "condition":"Objet en sucre + tourner sur soi m\u00eame"
+                    "condition": "Objet en sucre + tourner sur soi m\u00eame"
                 }
             ],
             "next": null,
@@ -122916,7 +122925,7 @@
                 {
                     "pokedex_id": 872,
                     "name": "Frissonille",
-                    "condition":"Bonheur + Jour + 1 niveau"
+                    "condition": "Bonheur + Jour + 1 niveau"
                 }
             ],
             "next": null,
@@ -123698,7 +123707,7 @@
                 {
                     "pokedex_id": 878,
                     "name": "Charibari",
-                    "condition":"Niveau 34"
+                    "condition": "Niveau 34"
                 }
             ],
             "next": null,
@@ -124657,7 +124666,7 @@
                 {
                     "pokedex_id": 885,
                     "name": "Fantyrm",
-                    "condition":"Niveau 50"
+                    "condition": "Niveau 50"
                 }
             ],
             "next": [
@@ -124808,12 +124817,12 @@
                 {
                     "pokedex_id": 885,
                     "name": "Fantyrm",
-                    "condition":"Niveau 50"
+                    "condition": "Niveau 50"
                 },
                 {
                     "pokedex_id": 886,
                     "name": "Dispareptil",
-                    "condition":"Niveau 60"
+                    "condition": "Niveau 60"
                 }
             ],
             "next": null,
@@ -125441,7 +125450,7 @@
                 {
                     "pokedex_id": 891,
                     "name": "Wushours",
-                    "condition":"Terminer l'ascension de la Tour de l'Eau / Tour des T\u00e9n\u00e8bres"
+                    "condition": "Terminer l'ascension de la Tour de l'Eau / Tour des T\u00e9n\u00e8bres"
                 }
             ],
             "next": null,
@@ -126297,7 +126306,9 @@
         },
         "height": "1,8 m",
         "weight": "95,1 kg",
-        "egg_groups": ["Terrestre"],
+        "egg_groups": [
+            "Terrestre"
+        ],
         "sexe": {
             "male": 50.0,
             "female": 50.0
@@ -126431,7 +126442,7 @@
                 {
                     "pokedex_id": 123,
                     "name": "Ins\u00e9cateur",
-                    "condition":"Avec une obsidienne"
+                    "condition": "Avec une obsidienne"
                 }
             ],
             "next": null,
@@ -126439,7 +126450,9 @@
         },
         "height": "1,8 m",
         "weight": "89,0 kg",
-        "egg_groups": ["Insecto\u00efde"],
+        "egg_groups": [
+            "Insecto\u00efde"
+        ],
         "sexe": {
             "male": 50.0,
             "female": 50.0
@@ -126573,12 +126586,12 @@
                 {
                     "pokedex_id": 216,
                     "name": "Teddiursa",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 },
                 {
                     "pokedex_id": 217,
                     "name": "Ursaring",
-                    "condition":"Avec un Bloc de Tourbe lors d'une nuit de pleine lune"
+                    "condition": "Avec un Bloc de Tourbe lors d'une nuit de pleine lune"
                 }
             ],
             "next": null,
@@ -126586,7 +126599,9 @@
         },
         "height": "2,4 m",
         "weight": "290,0 kg",
-        "egg_groups": ["Terrestre"],
+        "egg_groups": [
+            "Terrestre"
+        ],
         "sexe": {
             "male": 50.0,
             "female": 50.0
@@ -126720,7 +126735,7 @@
                 {
                     "pokedex_id": 550,
                     "name": "Bargantua",
-                    "condition":"Si Motif Blanc + Avoir perdu 294 PV ou plus par contrecoup"
+                    "condition": "Si Motif Blanc + Avoir perdu 294 PV ou plus par contrecoup"
                 }
             ],
             "next": null,
@@ -126728,7 +126743,9 @@
         },
         "height": "3,0 m",
         "weight": "110,0 kg",
-        "egg_groups": ["Aquatique 2"],
+        "egg_groups": [
+            "Aquatique 2"
+        ],
         "sexe": {
             "male": 50.0,
             "female": 50.0
@@ -126862,7 +126879,7 @@
                 {
                     "pokedex_id": 215,
                     "name": "Farfuret de Hisui",
-                    "condition":"+1 Niveau avec Griffe Rasoir / Contact d'une Griffe Rasoir"
+                    "condition": "+1 Niveau avec Griffe Rasoir / Contact d'une Griffe Rasoir"
                 }
             ],
             "next": null,
@@ -126870,7 +126887,9 @@
         },
         "height": "1,3 m",
         "weight": "43,0 kg",
-        "egg_groups": ["Terrestre"],
+        "egg_groups": [
+            "Terrestre"
+        ],
         "sexe": {
             "male": 50.0,
             "female": 50.0
@@ -127004,7 +127023,7 @@
                 {
                     "pokedex_id": 211,
                     "name": "Qwilfish de Hisui",
-                    "condition":"Utilise 20 fois ou plus la capacit\u00e9 sous Style Puissant"
+                    "condition": "Utilise 20 fois ou plus la capacit\u00e9 sous Style Puissant"
                 }
             ],
             "next": null,
@@ -127012,7 +127031,9 @@
         },
         "height": "2,5 m",
         "weight": "60,5 kg",
-        "egg_groups": ["Aquatique 2"],
+        "egg_groups": [
+            "Aquatique 2"
+        ],
         "sexe": {
             "male": 50.0,
             "female": 50.0
@@ -127408,7 +127429,7 @@
                 {
                     "pokedex_id": 906,
                     "name": "Poussacha",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -127555,12 +127576,12 @@
                 {
                     "pokedex_id": 906,
                     "name": "Poussacha",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 907,
                     "name": "Matourgeon",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -127838,7 +127859,7 @@
                 {
                     "pokedex_id": 909,
                     "name": "Chochodile",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -127984,12 +128005,12 @@
                 {
                     "pokedex_id": 909,
                     "name": "Chochodile",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 910,
                     "name": "Crocogril",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -128267,7 +128288,7 @@
                 {
                     "pokedex_id": 912,
                     "name": "Coiffeton",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 }
             ],
             "next": [
@@ -128414,12 +128435,12 @@
                 {
                     "pokedex_id": 912,
                     "name": "Coiffeton",
-                    "condition":"Niveau 16"
+                    "condition": "Niveau 16"
                 },
                 {
                     "pokedex_id": 913,
                     "name": "Canarbello",
-                    "condition":"Niveau 36"
+                    "condition": "Niveau 36"
                 }
             ],
             "next": null,
@@ -128704,7 +128725,7 @@
                 {
                     "pokedex_id": 915,
                     "name": "Gourmelet",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 }
             ],
             "next": null,
@@ -128976,7 +128997,7 @@
                 {
                     "pokedex_id": 917,
                     "name": "Tissenboule",
-                    "condition":"Niveau 15"
+                    "condition": "Niveau 15"
                 }
             ],
             "next": null,
@@ -129252,7 +129273,7 @@
                 {
                     "pokedex_id": 919,
                     "name": "Lilliterelle",
-                    "condition":"Niveau 24"
+                    "condition": "Niveau 24"
                 }
             ],
             "next": null,
@@ -129541,7 +129562,7 @@
                 {
                     "pokedex_id": 921,
                     "name": "Pohm",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 }
             ],
             "next": [
@@ -129691,12 +129712,12 @@
                 {
                     "pokedex_id": 921,
                     "name": "Pohm",
-                    "condition":"Niveau 18"
+                    "condition": "Niveau 18"
                 },
                 {
                     "pokedex_id": 922,
                     "name": "Pohmotte",
-                    "condition":"Marcher 1000 pas avec En Avant ! + 1 Niveau"
+                    "condition": "Marcher 1000 pas avec En Avant ! + 1 Niveau"
                 }
             ],
             "next": null,
@@ -130245,7 +130266,7 @@
                 {
                     "pokedex_id": 926,
                     "name": "P\u00e2tachiot",
-                    "condition":"Niveau 26"
+                    "condition": "Niveau 26"
                 }
             ],
             "next": null,
@@ -130531,7 +130552,7 @@
                 {
                     "pokedex_id": 928,
                     "name": "Olivini",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 }
             ],
             "next": [
@@ -130677,12 +130698,12 @@
                 {
                     "pokedex_id": 928,
                     "name": "Olivini",
-                    "condition":"Niveau 25"
+                    "condition": "Niveau 25"
                 },
                 {
                     "pokedex_id": 929,
                     "name": "Olivado",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 }
             ],
             "next": null,
@@ -131101,7 +131122,7 @@
                 {
                     "pokedex_id": 932,
                     "name": "Selutin",
-                    "condition":"Niveau 24"
+                    "condition": "Niveau 24"
                 }
             ],
             "next": [
@@ -131247,12 +131268,12 @@
                 {
                     "pokedex_id": 932,
                     "name": "Selutin",
-                    "condition":"Niveau 24"
+                    "condition": "Niveau 24"
                 },
                 {
                     "pokedex_id": 933,
                     "name": "Amassel",
-                    "condition":"Niveau 38"
+                    "condition": "Niveau 38"
                 }
             ],
             "next": null,
@@ -131533,7 +131554,7 @@
                 {
                     "pokedex_id": 935,
                     "name": "Charbambin",
-                    "condition":"Armure de la Fortune"
+                    "condition": "Armure de la Fortune"
                 }
             ],
             "next": null,
@@ -131673,7 +131694,7 @@
                 {
                     "pokedex_id": 935,
                     "name": "Charbambin",
-                    "condition":"Armure de la Rancune"
+                    "condition": "Armure de la Rancune"
                 }
             ],
             "next": null,
@@ -131953,7 +131974,7 @@
                 {
                     "pokedex_id": 938,
                     "name": "T\u00eatampoule",
-                    "condition":"Pierre Foudre"
+                    "condition": "Pierre Foudre"
                 }
             ],
             "next": null,
@@ -132242,7 +132263,7 @@
                 {
                     "pokedex_id": 940,
                     "name": "Zap\u00e9trel",
-                    "conditio":"Niveau 25"
+                    "condition": "Niveau 25"
                 }
             ],
             "next": null,
@@ -132523,7 +132544,7 @@
                 {
                     "pokedex_id": 942,
                     "name": "Grondogue",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -132811,7 +132832,7 @@
                 {
                     "pokedex_id": 944,
                     "name": "Gribouraigne",
-                    "condition":"Niveau 28"
+                    "condition": "Niveau 28"
                 }
             ],
             "next": null,
@@ -133222,13 +133243,13 @@
                 "multiplier": 1
             }
         ],
-        "evolution":{
+        "evolution": {
             "pre": null,
             "next": [
                 {
                     "pokedex_id": 949,
                     "name": "Terracruel",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "mega": null
@@ -133363,7 +133384,7 @@
                 {
                     "pokedex_id": 948,
                     "name": "Terracool",
-                    "condition":"Niveau 30"
+                    "condition": "Niveau 30"
                 }
             ],
             "next": null,
@@ -133777,7 +133798,7 @@
                 {
                     "pokedex_id": 951,
                     "name": "Pimito",
-                    "condition":"Pierre Feu"
+                    "condition": "Pierre Feu"
                 }
             ],
             "next": null,
@@ -134333,7 +134354,7 @@
                 {
                     "pokedex_id": 955,
                     "name": "Flotillon",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 }
             ],
             "next": null,
@@ -134626,7 +134647,7 @@
                 {
                     "pokedex_id": 957,
                     "name": "Forgerette",
-                    "condition":"Niveau 24"
+                    "condition": "Niveau 24"
                 }
             ],
             "next": [
@@ -134776,12 +134797,12 @@
                 {
                     "pokedex_id": 957,
                     "name": "Forgerette",
-                    "condition":"Niveau 24"
+                    "condition": "Niveau 24"
                 },
                 {
                     "pokedex_id": 958,
                     "name": "Forgella",
-                    "condition":"Niveau 38"
+                    "condition": "Niveau 38"
                 }
             ],
             "next": null,
@@ -135061,7 +135082,7 @@
                 {
                     "pokedex_id": 960,
                     "name": "Taupikeau",
-                    "condition":"Niveau 26"
+                    "condition": "Niveau 26"
                 }
             ],
             "next": null,
@@ -135460,7 +135481,7 @@
                 {
                     "pokedex_id": 963,
                     "name": "Dofin",
-                    "condition":"Niveau 38 en coop"
+                    "condition": "Niveau 38 en coop"
                 }
             ],
             "next": null,
@@ -135741,7 +135762,7 @@
                 {
                     "pokedex_id": 965,
                     "name": "Vrombi",
-                    "condition":"Niveau 40"
+                    "condition": "Niveau 40"
                 }
             ],
             "next": null,
@@ -136277,7 +136298,7 @@
                 {
                     "pokedex_id": 969,
                     "name": "Germ\u00e9clat",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 }
             ],
             "next": null,
@@ -136549,7 +136570,7 @@
                 {
                     "pokedex_id": 971,
                     "name": "Toutombe",
-                    "condition":"Niveau 30 pendant la nuit"
+                    "condition": "Niveau 30 pendant la nuit"
                 }
             ],
             "next": null,
@@ -136963,7 +136984,7 @@
                 {
                     "pokedex_id": 974,
                     "name": "Pi\u00e9tac\u00e9",
-                    "condition":"Pierre Glace"
+                    "condition": "Pierre Glace"
                 }
             ],
             "next": null,
@@ -137497,12 +137518,12 @@
                 {
                     "pokedex_id": 56,
                     "name": "F\u00e9rosinge",
-                    "condition":"Niveau 28"
+                    "condition": "Niveau 28"
                 },
                 {
                     "pokedex_id": 57,
                     "name": "Colossinge",
-                    "condition":"Utilise 20 fois la capacit\u00e9 Poing de Col\u00e8re + gain de niveau"
+                    "condition": "Utilise 20 fois la capacit\u00e9 Poing de Col\u00e8re + gain de niveau"
                 }
             ],
             "next": null,
@@ -137646,7 +137667,7 @@
                 {
                     "pokedex_id": 194,
                     "name": "Axoloto de Paldea",
-                    "condition":"Niveau 20"
+                    "condition": "Niveau 20"
                 }
             ],
             "next": null,
@@ -137791,7 +137812,7 @@
                 {
                     "pokedex_id": 203,
                     "name": "Girafarig",
-                    "condition":"+1 Niveau avec Double Laser"
+                    "condition": "+1 Niveau avec Double Laser"
                 }
             ],
             "next": null,
@@ -137931,7 +137952,7 @@
                 {
                     "pokedex_id": 206,
                     "name": "Insolourdo",
-                    "condition":"+1 Niveau avec Hyperceuse"
+                    "condition": "+1 Niveau avec Hyperceuse"
                 }
             ],
             "next": null,
@@ -138075,12 +138096,12 @@
                 {
                     "pokedex_id": 624,
                     "name": "Scalpion",
-                    "condition":"Niveau 52"
+                    "condition": "Niveau 52"
                 },
                 {
                     "pokedex_id": 625,
                     "name": "Scalproie",
-                    "condition":"Vaincre 3 Scalproie avec Embl\u00e8me du G\u00e9n\u00e9ral + 1 Niveau"
+                    "condition": "Vaincre 3 Scalproie avec Embl\u00e8me du G\u00e9n\u00e9ral + 1 Niveau"
                 }
             ],
             "next": null,
@@ -139673,12 +139694,12 @@
                 {
                     "pokedex_id": 997,
                     "name": "Cryodo",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 },
                 {
                     "pokedex_id": 998,
                     "name": "Glaivodo",
-                    "condition":"Niveau 54"
+                    "condition": "Niveau 54"
                 }
             ],
             "mega": null
@@ -139818,14 +139839,14 @@
                 {
                     "pokedex_id": 996,
                     "name": "Frigodo",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 }
             ],
             "next": [
                 {
                     "pokedex_id": 998,
                     "name": "Glaivodo",
-                    "condition":"Niveau 54"
+                    "condition": "Niveau 54"
                 }
             ],
             "mega": null
@@ -139965,12 +139986,12 @@
                 {
                     "pokedex_id": 996,
                     "name": "Frigodo",
-                    "condition":"Niveau 35"
+                    "condition": "Niveau 35"
                 },
                 {
                     "pokedex_id": 997,
                     "name": "Cryodo",
-                    "condition":"Niveau 54"
+                    "condition": "Niveau 54"
                 }
             ],
             "next": null,
@@ -141458,1959 +141479,1959 @@
         "level_100": 1250000,
         "formes": null
     },
-	{
-    "pokedex_id": 1011,
-    "generation": 9,
-    "category": "Pok\u00E9mon Sirop Pomme",
-    "name": {
-      "fr": "Pomdramour",
-      "en": "Dipplin",
-      "jp": "カミッチュ"
-    },
-    "sprites": {
-      "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1011/regular.png",
-      "shiny": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1011/shiny.png",
-      "gmax": null
-    },
-    "types": [
-      {
-        "name": "Plante",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/plante.png"
-      },
-      {
-        "name": "Dragon",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/dragon.png"
-      }
-    ],
-    "talents": [
-      {
-        "name": "Nectar Mielleux",
-        "tc": false
-      },
-      {
-        "name": "Gloutonnerie",
-        "tc": false
-      },
-      {
-        "name": "Glu",
-        "tc": true
-      }
-    ],
-    "stats": {
-      "hp": 80,
-      "atk": 80,
-      "def": 110,
-      "spe_atk": 95,
-      "spe_def": 80,
-      "vit": 40
-    },
-    "resistances": [
-      {
-        "name": "Normal",
-        "multiplier": 1
-      },
-      {
-        "name": "Plante",
-        "multiplier": 0.25
-      },
-      {
-        "name": "Feu",
-        "multiplier": 1
-      },
-      {
-        "name": "Eau",
-        "multiplier": 0.25
-      },
-      {
-        "name": "\u00C9lectrik",
-        "multiplier": 0.25
-      },
-      {
-        "name": "Glace",
-        "multiplier": 4
-      },
-      {
-        "name": "Combat",
-        "multiplier": 1
-      },
-      {
-        "name": "Poison",
-        "multiplier": 2
-      },
-      {
-        "name": "Sol",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Vol",
-        "multiplier": 2
-      },
-      {
-        "name": "Psy",
-        "multiplier": 1
-      },
-      {
-        "name": "Insecte",
-        "multiplier": 2
-      },
-      {
-        "name": "Roche",
-        "multiplier": 1
-      },
-      {
-        "name": "Spectre",
-        "multiplier": 1
-      },
-      {
-        "name": "Dragon",
-        "multiplier": 2
-      },
-      {
-        "name": "T\u00E9nèbres",
-        "multiplier": 1
-      },
-      {
-        "name": "Acier",
-        "multiplier": 1
-      },
-      {
-        "name": "F\u00E9e",
-        "multiplier": 2
-      }
-    ],
-    "evolution": {
-      "pre": [
-        {
-          "pokedex_id": 840,
-          "name": "Verpom",
-          "condition": "Avec une Pomme Nectar"
-        }
-      ],
-      "next": [
-         {
-            "pokedex_id": 1019,
-            "name": "Pomdorochi",
-            "condition": "Connaitre Cri Draconique + 1 niveau"
-         }
-      ],
-      "mega": null
-    },
-    "height": "0,4 m",
-    "weight": "4,4 kg",
-    "egg_groups": [
-      "V\u00E9g\u00E9tal",
-      "Draconique"
-    ],
-    "sexe": {
-      "male": 50,
-      "female": 50
-    },
-    "catch_rate": 45,
-    "level_100": 600000,
-    "formes": null
-  },
-  {
-    "pokedex_id": 1012,
-    "generation": 9,
-    "category": "Pok\u00E9mon Matcha",
-    "name": {
-      "fr": "Poltchageist",
-      "en": "Poltchageist",
-      "jp": "チャデス"
-    },
-    "sprites": {
-      "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1012/regular.png",
-      "shiny": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1012/shiny.png",
-      "gmax": null
-    },
-    "types": [
-      {
-        "name": "Plante",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/plante.png"
-      },
-      {
-        "name": "Spectre",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/spectre.png"
-      }
-    ],
-    "talents": [
-      {
-        "name": "Aux Petits Soins",
-        "tc": false
-      },
-      {
-        "name": "Ignifugi\u00E9",
-        "tc": true
-      }
-    ],
-    "stats": {
-      "hp": 40,
-      "atk": 45,
-      "def": 45,
-      "spe_atk": 74,
-      "spe_def": 54,
-      "vit": 50
-    },
-    "resistances": [
-      {
-        "name": "Normal",
-        "multiplier": 0
-      },
-      {
-        "name": "Plante",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Feu",
-        "multiplier": 2
-      },
-      {
-        "name": "Eau",
-        "multiplier": 0.5
-      },
-      {
-        "name": "\u00C9lectrik",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Glace",
-        "multiplier": 2
-      },
-      {
-        "name": "Combat",
-        "multiplier": 0
-      },
-      {
-        "name": "Poison",
-        "multiplier": 1
-      },
-      {
-        "name": "Sol",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Vol",
-        "multiplier": 2
-      },
-      {
-        "name": "Psy",
-        "multiplier": 1
-      },
-      {
-        "name": "Insecte",
-        "multiplier": 1
-      },
-      {
-        "name": "Roche",
-        "multiplier": 1
-      },
-      {
-        "name": "Spectre",
-        "multiplier": 2
-      },
-      {
-        "name": "Dragon",
-        "multiplier": 1
-      },
-      {
-        "name": "T\u00E9nèbres",
-        "multiplier": 2
-      },
-      {
-        "name": "Acier",
-        "multiplier": 1
-      },
-      {
-        "name": "F\u00E9e",
-        "multiplier": 1
-      }
-    ],
-    "evolution": {
-      "pre": null,
-      "next": [
-        {
-          "pokedex_id": 1013,
-          "name": "Th\u00E9ffroyable",
-          "condition": "Avec un Bol M\u00E9diocre ou un Bol Exceptionnel"
-        }
-      ],
-      "mega": null
-    },
-    "height": "0,1 m",
-    "weight": "1,1 kg",
-    "egg_groups": [
-      "Amorphe",
-      "Min\u00E9ral"
-    ],
-    "sexe": null,
-    "catch_rate": 120,
-    "level_100": 1059860,
-    "formes": null
-  },
-  {
-    "pokedex_id": 1013,
-    "generation": 9,
-    "category": "Pok\u00E9mon Matcha",
-    "name": {
-      "fr": "Th\u00E9ffroyable",
-      "en": "Sinistcha",
-      "jp": "ヤバソチャ"
-    },
-    "sprites": {
-      "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1013/regular.png",
-      "shiny": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1013/shiny.png",
-      "gmax": null
-    },
-    "types": [
-      {
-        "name": "Plante",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/plante.png"
-      },
-      {
-        "name": "Spectre",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/spectre.png"
-      }
-    ],
-    "talents": [
-      {
-        "name": "Aux Petits Soins",
-        "tc": false
-      },
-      {
-        "name": "Ignifugi\u00E9",
-        "tc": true
-      }
-    ],
-    "stats": {
-      "hp": 71,
-      "atk": 60,
-      "def": 106,
-      "spe_atk": 121,
-      "spe_def": 80,
-      "vit": 70
-    },
-    "resistances": [
-      {
-        "name": "Normal",
-        "multiplier": 0
-      },
-      {
-        "name": "Plante",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Feu",
-        "multiplier": 2
-      },
-      {
-        "name": "Eau",
-        "multiplier": 0.5
-      },
-      {
-        "name": "\u00C9lectrik",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Glace",
-        "multiplier": 2
-      },
-      {
-        "name": "Combat",
-        "multiplier": 0
-      },
-      {
-        "name": "Poison",
-        "multiplier": 1
-      },
-      {
-        "name": "Sol",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Vol",
-        "multiplier": 2
-      },
-      {
-        "name": "Psy",
-        "multiplier": 1
-      },
-      {
-        "name": "Insecte",
-        "multiplier": 1
-      },
-      {
-        "name": "Roche",
-        "multiplier": 1
-      },
-      {
-        "name": "Spectre",
-        "multiplier": 2
-      },
-      {
-        "name": "Dragon",
-        "multiplier": 1
-      },
-      {
-        "name": "T\u00E9nèbres",
-        "multiplier": 2
-      },
-      {
-        "name": "Acier",
-        "multiplier": 1
-      },
-      {
-        "name": "F\u00E9e",
-        "multiplier": 1
-      }
-    ],
-    "evolution": {
-      "pre": [
-        {
-          "pokedex_id": 1012,
-          "name": "Poltchageist",
-          "condition": "Avec un Bol M\u00E9diocre ou un Bol Exceptionnel"
-        }
-      ],
-      "next": null,
-      "mega": null
-    },
-    "height": "0,2 m",
-    "weight": "2,2 kg",
-    "egg_groups": [
-      "Amorphe",
-      "Min\u00E9ral"
-    ],
-    "sexe": null,
-    "catch_rate": 60,
-    "level_100": 1059860,
-    "formes": null
-  },
-  {
-    "pokedex_id": 1014,
-    "generation": 9,
-    "category": "Pok\u00E9mon Serviteur",
-    "name": {
-      "fr": "F\u00E9licanis",
-      "en": "Okidogi",
-      "jp": "イイネイヌ"
-    },
-    "sprites": {
-      "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1014/regular.png",
-      "shiny": null,
-      "gmax": null
-    },
-    "types": [
-      {
-        "name": "Poison",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/poison.png"
-      },
-      {
-        "name": "Combat",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/combat.png"
-      }
-    ],
-    "talents": [
-      {
-        "name": "Chaine Toxique",
-        "tc": false
-      },
-      {
-        "name": "Chien de Garde",
-        "tc": true
-      }
-    ],
-    "stats": {
-      "hp": 88,
-      "atk": 128,
-      "def": 115,
-      "spe_atk": 58,
-      "spe_def": 86,
-      "vit": 80
-    },
-    "resistances": [
-      {
-        "name": "Normal",
-        "multiplier": 1
-      },
-      {
-        "name": "Plante",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Feu",
-        "multiplier": 1
-      },
-      {
-        "name": "Eau",
-        "multiplier": 1
-      },
-      {
-        "name": "\u00C9lectrik",
-        "multiplier": 1
-      },
-      {
-        "name": "Glace",
-        "multiplier": 1
-      },
-      {
-        "name": "Combat",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Poison",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Sol",
-        "multiplier": 2
-      },
-      {
-        "name": "Vol",
-        "multiplier": 2
-      },
-      {
-        "name": "Psy",
-        "multiplier": 4
-      },
-      {
-        "name": "Insecte",
-        "multiplier": 0.25
-      },
-      {
-        "name": "Roche",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Spectre",
-        "multiplier": 1
-      },
-      {
-        "name": "Dragon",
-        "multiplier": 1
-      },
-      {
-        "name": "T\u00E9nèbres",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Acier",
-        "multiplier": 1
-      },
-      {
-        "name": "F\u00E9e",
-        "multiplier": 1
-      }
-    ],
-    "evolution": null,
-    "height": "1,8 m",
-    "weight": "92,2 kg",
-    "egg_groups": null,
-    "sexe": {
-      "male": 100,
-      "female": 0
-    },
-    "catch_rate": 3,
-    "level_100": 1250000,
-    "formes": null
-  },
-  {
-    "pokedex_id": 1015,
-    "generation": 9,
-    "category": "Pok\u00E9mon Serviteur",
-    "name": {
-      "fr": "Fortusimia",
-      "en": "Munkidori",
-      "jp": "マシマシラ"
-    },
-    "sprites": {
-      "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1015/regular.png",
-      "shiny": null,
-      "gmax": null
-    },
-    "types": [
-      {
-        "name": "Poison",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/poison.png"
-      },
-      {
-        "name": "Psy",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/psy.png"
-      }
-    ],
-    "talents": [
-      {
-        "name": "Chaine Toxique",
-        "tc": false
-      },
-      {
-        "name": "Fouille",
-        "tc": true
-      }
-    ],
-    "stats": {
-      "hp": 88,
-      "atk": 75,
-      "def": 66,
-      "spe_atk": 130,
-      "spe_def": 90,
-      "vit": 106
-    },
-    "resistances": [
-      {
-        "name": "Normal",
-        "multiplier": 1
-      },
-      {
-        "name": "Plante",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Feu",
-        "multiplier": 1
-      },
-      {
-        "name": "Eau",
-        "multiplier": 1
-      },
-      {
-        "name": "\u00C9lectrik",
-        "multiplier": 1
-      },
-      {
-        "name": "Glace",
-        "multiplier": 1
-      },
-      {
-        "name": "Combat",
-        "multiplier": 0.25
-      },
-      {
-        "name": "Poison",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Sol",
-        "multiplier": 2
-      },
-      {
-        "name": "Vol",
-        "multiplier": 1
-      },
-      {
-        "name": "Psy",
-        "multiplier": 1
-      },
-      {
-        "name": "Insecte",
-        "multiplier": 1
-      },
-      {
-        "name": "Roche",
-        "multiplier": 1
-      },
-      {
-        "name": "Spectre",
-        "multiplier": 2
-      },
-      {
-        "name": "Dragon",
-        "multiplier": 1
-      },
-      {
-        "name": "T\u00E9nèbres",
-        "multiplier": 2
-      },
-      {
-        "name": "Acier",
-        "multiplier": 1
-      },
-      {
-        "name": "F\u00E9e",
-        "multiplier": 0.5
-      }
-    ],
-    "evolution": null,
-    "height": "1,0 m",
-    "weight": "12,2 kg",
-    "egg_groups": null,
-    "sexe": {
-      "male": 100,
-      "female": 0
-    },
-    "catch_rate": 3,
-    "level_100": 1250000,
-    "formes": null
-  },
-  {
-    "pokedex_id": 1016,
-    "generation": 9,
-    "category": "Pok\u00E9mon Serviteur",
-    "name": {
-      "fr": "Favianos",
-      "en": "Fezandipiti",
-      "jp": "キチキギス"
-    },
-    "sprites": {
-      "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1016/regular.png",
-      "shiny": null,
-      "gmax": null
-    },
-    "types": [
-      {
-        "name": "Poison",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/poison.png"
-      },
-      {
-        "name": "F\u00E9e",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/fee.png"
-      }
-    ],
-    "talents": [
-      {
-        "name": "Chaine Toxique",
-        "tc": false
-      },
-      {
-        "name": "Technicien",
-        "tc": true
-      }
-    ],
-    "stats": {
-      "hp": 88,
-      "atk": 91,
-      "def": 82,
-      "spe_atk": 70,
-      "spe_def": 125,
-      "vit": 99
-    },
-    "resistances": [
-      {
-        "name": "Normal",
-        "multiplier": 1
-      },
-      {
-        "name": "Plante",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Feu",
-        "multiplier": 1
-      },
-      {
-        "name": "Eau",
-        "multiplier": 1
-      },
-      {
-        "name": "\u00C9lectrik",
-        "multiplier": 1
-      },
-      {
-        "name": "Glace",
-        "multiplier": 1
-      },
-      {
-        "name": "Combat",
-        "multiplier": 0.25
-      },
-      {
-        "name": "Poison",
-        "multiplier": 1
-      },
-      {
-        "name": "Sol",
-        "multiplier": 2
-      },
-      {
-        "name": "Vol",
-        "multiplier": 1
-      },
-      {
-        "name": "Psy",
-        "multiplier": 2
-      },
-      {
-        "name": "Insecte",
-        "multiplier": 0.25
-      },
-      {
-        "name": "Roche",
-        "multiplier": 1
-      },
-      {
-        "name": "Spectre",
-        "multiplier": 1
-      },
-      {
-        "name": "Dragon",
-        "multiplier": 0
-      },
-      {
-        "name": "T\u00E9nèbres",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Acier",
-        "multiplier": 2
-      },
-      {
-        "name": "F\u00E9e",
-        "multiplier": 0.5
-      }
-    ],
-    "evolution": null,
-    "height": "1,4 m",
-    "weight": "30,1 kg",
-    "egg_groups": null,
-    "sexe": {
-      "male": 100,
-      "female": 0
-    },
-    "catch_rate": 3,
-    "level_100": 1250000,
-    "formes": null
-  },
-  {
-    "pokedex_id": 1017,
-    "generation": 9,
-    "category": "Pok\u00E9mon Masque",
-    "name": {
-      "fr": "Ogerpon",
-      "en": "Ogerpon",
-      "jp": "オーガポン"
-    },
-    "sprites": {
-      "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1017/regular.png",
-      "shiny": null,
-      "gmax": null
-    },
-    "types": [
-      {
-        "name": "Plante",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/plante.png"
-      }
-    ],
-    "talents": [
-      {
-        "name": "Acharn\u00E9",
-        "tc": false
-      },
-      {
-        "name": "Force M\u00E9morielle",
-        "tc": true
-      }
-    ],
-    "stats": {
-      "hp": 80,
-      "atk": 120,
-      "def": 84,
-      "spe_atk": 60,
-      "spe_def": 96,
-      "vit": 110
-    },
-    "resistances": [
-      {
-        "name": "Normal",
-        "multiplier": 1
-      },
-      {
-        "name": "Plante",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Feu",
-        "multiplier": 2
-      },
-      {
-        "name": "Eau",
-        "multiplier": 0.5
-      },
-      {
-        "name": "\u00C9lectrik",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Glace",
-        "multiplier": 2
-      },
-      {
-        "name": "Combat",
-        "multiplier": 1
-      },
-      {
-        "name": "Poison",
-        "multiplier": 2
-      },
-      {
-        "name": "Sol",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Vol",
-        "multiplier": 2
-      },
-      {
-        "name": "Psy",
-        "multiplier": 1
-      },
-      {
-        "name": "Insecte",
-        "multiplier": 2
-      },
-      {
-        "name": "Roche",
-        "multiplier": 1
-      },
-      {
-        "name": "Spectre",
-        "multiplier": 1
-      },
-      {
-        "name": "Dragon",
-        "multiplier": 1
-      },
-      {
-        "name": "T\u00E9nèbres",
-        "multiplier": 1
-      },
-      {
-        "name": "Acier",
-        "multiplier": 1
-      },
-      {
-        "name": "F\u00E9e",
-        "multiplier": 1
-      }
-    ],
-    "evolution": null,
-    "height": "1,2 m",
-    "weight": "39,8 kg",
-    "egg_groups": null,
-    "sexe": {
-      "male": 0,
-      "female": 100
-    },
-    "catch_rate": 5,
-    "level_100": 1250000,
-    "formes": null
-  },
-  {
-    "pokedex_id": 1018,
-    "generation": 9,
-    "category": "Pok\u00E9mon Alliage",
-    "name": {
-      "fr": "Pondralugon",
-      "en": "Archaludon",
-      "jp": "\u30D6\u30EA\u30B8\u30E5\u30E9\u30B9"
-    },
-    "sprites": {
-      "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1018/regular.png",
-      "shiny": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1018/shiny.png",
-      "gmax": null
-    },
-    "types": [
-      {
-        "name": "Acier",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/acier.png"
-      },
-      {
-        "name": "Dragon",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/dragon.png"
-      }
-    ],
-    "talents": [
-      {
-        "name": "Endurance",
-        "tc": false
-      },
-      {
-        "name": "Fermet\u00e9",
-        "tc": false
-      },
-      {
-        "name": "Nerfs d'Acier",
-        "tc": true
-      }
-    ],
-    "stats": {
-      "hp": 90,
-      "atk": 105,
-      "def": 130,
-      "spe_atk": 125,
-      "spe_def": 65,
-      "vit": 85
-    },
-    "resistances": [
-      {
-        "name": "Normal",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Plante",
-        "multiplier": 0.25
-      },
-      {
-        "name": "Feu",
-        "multiplier": 1
-      },
-      {
-        "name": "Eau",
-        "multiplier": 0.5
-      },
-      {
-        "name": "\u00C9lectrik",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Glace",
-        "multiplier": 1
-      },
-      {
-        "name": "Combat",
-        "multiplier": 2
-      },
-      {
-        "name": "Poison",
-        "multiplier": 0
-      },
-      {
-        "name": "Sol",
-        "multiplier": 2
-      },
-      {
-        "name": "Vol",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Psy",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Insecte",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Roche",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Spectre",
-        "multiplier": 1
-      },
-      {
-        "name": "Dragon",
-        "multiplier": 1
-      },
-      {
-        "name": "T\u00E9nèbres",
-        "multiplier": 1
-      },
-      {
-        "name": "Acier",
-        "multiplier": 0.5
-      },
-      {
-        "name": "F\u00E9e",
-        "multiplier": 1
-      }
-    ],
-    "evolution": {
-        "pre": [
+    {
+        "pokedex_id": 1011,
+        "generation": 9,
+        "category": "Pok\u00E9mon Sirop Pomme",
+        "name": {
+            "fr": "Pomdramour",
+            "en": "Dipplin",
+            "jp": "カミッチュ"
+        },
+        "sprites": {
+            "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1011/regular.png",
+            "shiny": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1011/shiny.png",
+            "gmax": null
+        },
+        "types": [
             {
-                "pokedex_id": 884,
-                "name": "Duralugon",
-                "condition": "Avec un Métal Composite"
+                "name": "Plante",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/plante.png"
+            },
+            {
+                "name": "Dragon",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/dragon.png"
             }
         ],
-        "next": null,
-        "mega": null
-    },
-    "height": "2,0 m",
-    "weight": "60,0 kg",
-    "egg_groups": [
-        "Min\u00E9ral",
-        "Draconique"
-    ],
-    "sexe": {
-      "male": 50,
-      "female": 50
-    },
-    "catch_rate": 10,
-    "level_100": 1000000,
-    "formes": null
-  },
-  {
-    "pokedex_id": 1019,
-    "generation": 9,
-    "category": "Pok\u00E9mon Hydre Pomme",
-    "name": {
-      "fr": "Pomdorochi",
-      "en": "Hydrapple",
-      "jp": "\u30AB\u30DF\u30C4\u30AA\u30ED\u30C1"
-    },
-    "sprites": {
-      "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1019/regular.png",
-      "shiny": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1019/shiny.png",
-      "gmax": null
-    },
-    "types": [
-      {
-        "name": "Plante",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/plante.png"
-      },
-      {
-        "name": "Dragon",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/dragon.png"
-      }
-    ],
-    "talents": [
-      {
-        "name": "Nectar Mielleux",
-        "tc": false
-      },
-      {
-        "name": "R\u00e9g\u00e9-Force",
-        "tc": false
-      },
-      {
-        "name": "Glu",
-        "tc": true
-      }
-    ],
-    "stats": {
-      "hp": 106,
-      "atk": 80,
-      "def": 110,
-      "spe_atk": 120,
-      "spe_def": 80,
-      "vit": 44
-    },
-    "resistances": [
-      {
-        "name": "Normal",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Plante",
-        "multiplier": 0.25
-      },
-      {
-        "name": "Feu",
-        "multiplier": 1
-      },
-      {
-        "name": "Eau",
-        "multiplier": 0.25
-      },
-      {
-        "name": "\u00C9lectrik",
-        "multiplier": 0.25
-      },
-      {
-        "name": "Glace",
-        "multiplier": 4
-      },
-      {
-        "name": "Combat",
-        "multiplier": 1
-      },
-      {
-        "name": "Poison",
-        "multiplier": 2
-      },
-      {
-        "name": "Sol",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Vol",
-        "multiplier": 2
-      },
-      {
-        "name": "Psy",
-        "multiplier": 1
-      },
-      {
-        "name": "Insecte",
-        "multiplier": 2
-      },
-      {
-        "name": "Roche",
-        "multiplier": 1
-      },
-      {
-        "name": "Spectre",
-        "multiplier": 1
-      },
-      {
-        "name": "Dragon",
-        "multiplier": 2
-      },
-      {
-        "name": "T\u00E9nèbres",
-        "multiplier": 1
-      },
-      {
-        "name": "Acier",
-        "multiplier": 1
-      },
-      {
-        "name": "F\u00E9e",
-        "multiplier": 2
-      }
-    ],
-    "evolution": {
-        "pre": [
-          {
-            "pokedex_id": 840,
-            "name": "Verpom",
-            "condition": "Avec une Pomme Nectar"
-          },
-          {
-            "pokedex_id": 1011,
-            "name": "Pomdramour",
-            "condition": "Connaitre Cri Draconique + 1 niveau"
-         }
+        "talents": [
+            {
+                "name": "Nectar Mielleux",
+                "tc": false
+            },
+            {
+                "name": "Gloutonnerie",
+                "tc": false
+            },
+            {
+                "name": "Glu",
+                "tc": true
+            }
         ],
-        "next": null,
-        "mega": null
-      },
-    "height": "1,8 m",
-    "weight": "93,0 kg",
-    "egg_groups": [
-        "V\u00E9g\u00E9tal",
-        "Draconique"
-    ],
-    "sexe": {
-      "male": 50,
-      "female": 50
+        "stats": {
+            "hp": 80,
+            "atk": 80,
+            "def": 110,
+            "spe_atk": 95,
+            "spe_def": 80,
+            "vit": 40
+        },
+        "resistances": [
+            {
+                "name": "Normal",
+                "multiplier": 1
+            },
+            {
+                "name": "Plante",
+                "multiplier": 0.25
+            },
+            {
+                "name": "Feu",
+                "multiplier": 1
+            },
+            {
+                "name": "Eau",
+                "multiplier": 0.25
+            },
+            {
+                "name": "\u00C9lectrik",
+                "multiplier": 0.25
+            },
+            {
+                "name": "Glace",
+                "multiplier": 4
+            },
+            {
+                "name": "Combat",
+                "multiplier": 1
+            },
+            {
+                "name": "Poison",
+                "multiplier": 2
+            },
+            {
+                "name": "Sol",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Vol",
+                "multiplier": 2
+            },
+            {
+                "name": "Psy",
+                "multiplier": 1
+            },
+            {
+                "name": "Insecte",
+                "multiplier": 2
+            },
+            {
+                "name": "Roche",
+                "multiplier": 1
+            },
+            {
+                "name": "Spectre",
+                "multiplier": 1
+            },
+            {
+                "name": "Dragon",
+                "multiplier": 2
+            },
+            {
+                "name": "T\u00E9nèbres",
+                "multiplier": 1
+            },
+            {
+                "name": "Acier",
+                "multiplier": 1
+            },
+            {
+                "name": "F\u00E9e",
+                "multiplier": 2
+            }
+        ],
+        "evolution": {
+            "pre": [
+                {
+                    "pokedex_id": 840,
+                    "name": "Verpom",
+                    "condition": "Avec une Pomme Nectar"
+                }
+            ],
+            "next": [
+                {
+                    "pokedex_id": 1019,
+                    "name": "Pomdorochi",
+                    "condition": "Connaitre Cri Draconique + 1 niveau"
+                }
+            ],
+            "mega": null
+        },
+        "height": "0,4 m",
+        "weight": "4,4 kg",
+        "egg_groups": [
+            "V\u00E9g\u00E9tal",
+            "Draconique"
+        ],
+        "sexe": {
+            "male": 50,
+            "female": 50
+        },
+        "catch_rate": 45,
+        "level_100": 600000,
+        "formes": null
     },
-    "catch_rate": 10,
-    "level_100": 600000,
-    "formes": null
-  },
-  {
-    "pokedex_id": 1020,
-    "generation": 9,
-    "category": "Pok\u00E9mon Paradoxe",
-    "name": {
-      "fr": "Feu-Per\u00E7ant",
-      "en": "Gouging Fire",
-      "jp": "\u30A6\u30AC\u30C4\u30DB\u30E0\u30E9"
+    {
+        "pokedex_id": 1012,
+        "generation": 9,
+        "category": "Pok\u00E9mon Matcha",
+        "name": {
+            "fr": "Poltchageist",
+            "en": "Poltchageist",
+            "jp": "チャデス"
+        },
+        "sprites": {
+            "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1012/regular.png",
+            "shiny": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1012/shiny.png",
+            "gmax": null
+        },
+        "types": [
+            {
+                "name": "Plante",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/plante.png"
+            },
+            {
+                "name": "Spectre",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/spectre.png"
+            }
+        ],
+        "talents": [
+            {
+                "name": "Aux Petits Soins",
+                "tc": false
+            },
+            {
+                "name": "Ignifugi\u00E9",
+                "tc": true
+            }
+        ],
+        "stats": {
+            "hp": 40,
+            "atk": 45,
+            "def": 45,
+            "spe_atk": 74,
+            "spe_def": 54,
+            "vit": 50
+        },
+        "resistances": [
+            {
+                "name": "Normal",
+                "multiplier": 0
+            },
+            {
+                "name": "Plante",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Feu",
+                "multiplier": 2
+            },
+            {
+                "name": "Eau",
+                "multiplier": 0.5
+            },
+            {
+                "name": "\u00C9lectrik",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Glace",
+                "multiplier": 2
+            },
+            {
+                "name": "Combat",
+                "multiplier": 0
+            },
+            {
+                "name": "Poison",
+                "multiplier": 1
+            },
+            {
+                "name": "Sol",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Vol",
+                "multiplier": 2
+            },
+            {
+                "name": "Psy",
+                "multiplier": 1
+            },
+            {
+                "name": "Insecte",
+                "multiplier": 1
+            },
+            {
+                "name": "Roche",
+                "multiplier": 1
+            },
+            {
+                "name": "Spectre",
+                "multiplier": 2
+            },
+            {
+                "name": "Dragon",
+                "multiplier": 1
+            },
+            {
+                "name": "T\u00E9nèbres",
+                "multiplier": 2
+            },
+            {
+                "name": "Acier",
+                "multiplier": 1
+            },
+            {
+                "name": "F\u00E9e",
+                "multiplier": 1
+            }
+        ],
+        "evolution": {
+            "pre": null,
+            "next": [
+                {
+                    "pokedex_id": 1013,
+                    "name": "Th\u00E9ffroyable",
+                    "condition": "Avec un Bol M\u00E9diocre ou un Bol Exceptionnel"
+                }
+            ],
+            "mega": null
+        },
+        "height": "0,1 m",
+        "weight": "1,1 kg",
+        "egg_groups": [
+            "Amorphe",
+            "Min\u00E9ral"
+        ],
+        "sexe": null,
+        "catch_rate": 120,
+        "level_100": 1059860,
+        "formes": null
     },
-    "sprites": {
-      "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1020/regular.png",
-      "shiny": null,
-      "gmax": null
+    {
+        "pokedex_id": 1013,
+        "generation": 9,
+        "category": "Pok\u00E9mon Matcha",
+        "name": {
+            "fr": "Th\u00E9ffroyable",
+            "en": "Sinistcha",
+            "jp": "ヤバソチャ"
+        },
+        "sprites": {
+            "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1013/regular.png",
+            "shiny": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1013/shiny.png",
+            "gmax": null
+        },
+        "types": [
+            {
+                "name": "Plante",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/plante.png"
+            },
+            {
+                "name": "Spectre",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/spectre.png"
+            }
+        ],
+        "talents": [
+            {
+                "name": "Aux Petits Soins",
+                "tc": false
+            },
+            {
+                "name": "Ignifugi\u00E9",
+                "tc": true
+            }
+        ],
+        "stats": {
+            "hp": 71,
+            "atk": 60,
+            "def": 106,
+            "spe_atk": 121,
+            "spe_def": 80,
+            "vit": 70
+        },
+        "resistances": [
+            {
+                "name": "Normal",
+                "multiplier": 0
+            },
+            {
+                "name": "Plante",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Feu",
+                "multiplier": 2
+            },
+            {
+                "name": "Eau",
+                "multiplier": 0.5
+            },
+            {
+                "name": "\u00C9lectrik",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Glace",
+                "multiplier": 2
+            },
+            {
+                "name": "Combat",
+                "multiplier": 0
+            },
+            {
+                "name": "Poison",
+                "multiplier": 1
+            },
+            {
+                "name": "Sol",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Vol",
+                "multiplier": 2
+            },
+            {
+                "name": "Psy",
+                "multiplier": 1
+            },
+            {
+                "name": "Insecte",
+                "multiplier": 1
+            },
+            {
+                "name": "Roche",
+                "multiplier": 1
+            },
+            {
+                "name": "Spectre",
+                "multiplier": 2
+            },
+            {
+                "name": "Dragon",
+                "multiplier": 1
+            },
+            {
+                "name": "T\u00E9nèbres",
+                "multiplier": 2
+            },
+            {
+                "name": "Acier",
+                "multiplier": 1
+            },
+            {
+                "name": "F\u00E9e",
+                "multiplier": 1
+            }
+        ],
+        "evolution": {
+            "pre": [
+                {
+                    "pokedex_id": 1012,
+                    "name": "Poltchageist",
+                    "condition": "Avec un Bol M\u00E9diocre ou un Bol Exceptionnel"
+                }
+            ],
+            "next": null,
+            "mega": null
+        },
+        "height": "0,2 m",
+        "weight": "2,2 kg",
+        "egg_groups": [
+            "Amorphe",
+            "Min\u00E9ral"
+        ],
+        "sexe": null,
+        "catch_rate": 60,
+        "level_100": 1059860,
+        "formes": null
     },
-    "types": [
-      {
-        "name": "Feu",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/feu.png"
-      },
-      {
-        "name": "Dragon",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/dragon.png"
-      }
-    ],
-    "talents": [
-      {
-        "name": "Pal\u00e9osynth\u00e8se",
-        "tc": false
-      }
-    ],
-    "stats": {
-      "hp": 105,
-      "atk": 115,
-      "def": 121,
-      "spe_atk": 65,
-      "spe_def": 93,
-      "vit": 91
+    {
+        "pokedex_id": 1014,
+        "generation": 9,
+        "category": "Pok\u00E9mon Serviteur",
+        "name": {
+            "fr": "F\u00E9licanis",
+            "en": "Okidogi",
+            "jp": "イイネイヌ"
+        },
+        "sprites": {
+            "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1014/regular.png",
+            "shiny": null,
+            "gmax": null
+        },
+        "types": [
+            {
+                "name": "Poison",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/poison.png"
+            },
+            {
+                "name": "Combat",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/combat.png"
+            }
+        ],
+        "talents": [
+            {
+                "name": "Chaine Toxique",
+                "tc": false
+            },
+            {
+                "name": "Chien de Garde",
+                "tc": true
+            }
+        ],
+        "stats": {
+            "hp": 88,
+            "atk": 128,
+            "def": 115,
+            "spe_atk": 58,
+            "spe_def": 86,
+            "vit": 80
+        },
+        "resistances": [
+            {
+                "name": "Normal",
+                "multiplier": 1
+            },
+            {
+                "name": "Plante",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Feu",
+                "multiplier": 1
+            },
+            {
+                "name": "Eau",
+                "multiplier": 1
+            },
+            {
+                "name": "\u00C9lectrik",
+                "multiplier": 1
+            },
+            {
+                "name": "Glace",
+                "multiplier": 1
+            },
+            {
+                "name": "Combat",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Poison",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Sol",
+                "multiplier": 2
+            },
+            {
+                "name": "Vol",
+                "multiplier": 2
+            },
+            {
+                "name": "Psy",
+                "multiplier": 4
+            },
+            {
+                "name": "Insecte",
+                "multiplier": 0.25
+            },
+            {
+                "name": "Roche",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Spectre",
+                "multiplier": 1
+            },
+            {
+                "name": "Dragon",
+                "multiplier": 1
+            },
+            {
+                "name": "T\u00E9nèbres",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Acier",
+                "multiplier": 1
+            },
+            {
+                "name": "F\u00E9e",
+                "multiplier": 1
+            }
+        ],
+        "evolution": null,
+        "height": "1,8 m",
+        "weight": "92,2 kg",
+        "egg_groups": null,
+        "sexe": {
+            "male": 100,
+            "female": 0
+        },
+        "catch_rate": 3,
+        "level_100": 1250000,
+        "formes": null
     },
-    "resistances": [
-      {
-        "name": "Normal",
-        "multiplier": 1
-      },
-      {
-        "name": "Plante",
-        "multiplier": 0.25
-      },
-      {
-        "name": "Feu",
-        "multiplier": 0.25
-      },
-      {
-        "name": "Eau",
-        "multiplier": 1
-      },
-      {
-        "name": "\u00C9lectrik",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Glace",
-        "multiplier": 1
-      },
-      {
-        "name": "Combat",
-        "multiplier": 1
-      },
-      {
-        "name": "Poison",
-        "multiplier": 1
-      },
-      {
-        "name": "Sol",
-        "multiplier": 2
-      },
-      {
-        "name": "Vol",
-        "multiplier": 1
-      },
-      {
-        "name": "Psy",
-        "multiplier": 1
-      },
-      {
-        "name": "Insecte",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Roche",
-        "multiplier": 2
-      },
-      {
-        "name": "Spectre",
-        "multiplier": 1
-      },
-      {
-        "name": "Dragon",
-        "multiplier": 2
-      },
-      {
-        "name": "T\u00E9nèbres",
-        "multiplier": 1
-      },
-      {
-        "name": "Acier",
-        "multiplier": 0.5
-      },
-      {
-        "name": "F\u00E9e",
-        "multiplier": 1
-      }
-    ],
-    "evolution": null,
-    "height": "3,5 m",
-    "weight": "590,0 kg",
-    "egg_groups": null,
-    "sexe": null,
-    "catch_rate": 10,
-    "level_100": 1250000,
-    "formes": null
-  },
-  {
-    "pokedex_id": 1021,
-    "generation": 9,
-    "category": "Pok\u00E9mon Paradoxe",
-    "name": {
-      "fr": "Ire-Foudre",
-      "en": "Raging Bolt",
-      "jp": "\u30BF\u30B1\u30EB\u30E9\u30A4\u30B3"
+    {
+        "pokedex_id": 1015,
+        "generation": 9,
+        "category": "Pok\u00E9mon Serviteur",
+        "name": {
+            "fr": "Fortusimia",
+            "en": "Munkidori",
+            "jp": "マシマシラ"
+        },
+        "sprites": {
+            "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1015/regular.png",
+            "shiny": null,
+            "gmax": null
+        },
+        "types": [
+            {
+                "name": "Poison",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/poison.png"
+            },
+            {
+                "name": "Psy",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/psy.png"
+            }
+        ],
+        "talents": [
+            {
+                "name": "Chaine Toxique",
+                "tc": false
+            },
+            {
+                "name": "Fouille",
+                "tc": true
+            }
+        ],
+        "stats": {
+            "hp": 88,
+            "atk": 75,
+            "def": 66,
+            "spe_atk": 130,
+            "spe_def": 90,
+            "vit": 106
+        },
+        "resistances": [
+            {
+                "name": "Normal",
+                "multiplier": 1
+            },
+            {
+                "name": "Plante",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Feu",
+                "multiplier": 1
+            },
+            {
+                "name": "Eau",
+                "multiplier": 1
+            },
+            {
+                "name": "\u00C9lectrik",
+                "multiplier": 1
+            },
+            {
+                "name": "Glace",
+                "multiplier": 1
+            },
+            {
+                "name": "Combat",
+                "multiplier": 0.25
+            },
+            {
+                "name": "Poison",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Sol",
+                "multiplier": 2
+            },
+            {
+                "name": "Vol",
+                "multiplier": 1
+            },
+            {
+                "name": "Psy",
+                "multiplier": 1
+            },
+            {
+                "name": "Insecte",
+                "multiplier": 1
+            },
+            {
+                "name": "Roche",
+                "multiplier": 1
+            },
+            {
+                "name": "Spectre",
+                "multiplier": 2
+            },
+            {
+                "name": "Dragon",
+                "multiplier": 1
+            },
+            {
+                "name": "T\u00E9nèbres",
+                "multiplier": 2
+            },
+            {
+                "name": "Acier",
+                "multiplier": 1
+            },
+            {
+                "name": "F\u00E9e",
+                "multiplier": 0.5
+            }
+        ],
+        "evolution": null,
+        "height": "1,0 m",
+        "weight": "12,2 kg",
+        "egg_groups": null,
+        "sexe": {
+            "male": 100,
+            "female": 0
+        },
+        "catch_rate": 3,
+        "level_100": 1250000,
+        "formes": null
     },
-    "sprites": {
-      "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1021/regular.png",
-      "shiny": null,
-      "gmax": null
+    {
+        "pokedex_id": 1016,
+        "generation": 9,
+        "category": "Pok\u00E9mon Serviteur",
+        "name": {
+            "fr": "Favianos",
+            "en": "Fezandipiti",
+            "jp": "キチキギス"
+        },
+        "sprites": {
+            "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1016/regular.png",
+            "shiny": null,
+            "gmax": null
+        },
+        "types": [
+            {
+                "name": "Poison",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/poison.png"
+            },
+            {
+                "name": "F\u00E9e",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/fee.png"
+            }
+        ],
+        "talents": [
+            {
+                "name": "Chaine Toxique",
+                "tc": false
+            },
+            {
+                "name": "Technicien",
+                "tc": true
+            }
+        ],
+        "stats": {
+            "hp": 88,
+            "atk": 91,
+            "def": 82,
+            "spe_atk": 70,
+            "spe_def": 125,
+            "vit": 99
+        },
+        "resistances": [
+            {
+                "name": "Normal",
+                "multiplier": 1
+            },
+            {
+                "name": "Plante",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Feu",
+                "multiplier": 1
+            },
+            {
+                "name": "Eau",
+                "multiplier": 1
+            },
+            {
+                "name": "\u00C9lectrik",
+                "multiplier": 1
+            },
+            {
+                "name": "Glace",
+                "multiplier": 1
+            },
+            {
+                "name": "Combat",
+                "multiplier": 0.25
+            },
+            {
+                "name": "Poison",
+                "multiplier": 1
+            },
+            {
+                "name": "Sol",
+                "multiplier": 2
+            },
+            {
+                "name": "Vol",
+                "multiplier": 1
+            },
+            {
+                "name": "Psy",
+                "multiplier": 2
+            },
+            {
+                "name": "Insecte",
+                "multiplier": 0.25
+            },
+            {
+                "name": "Roche",
+                "multiplier": 1
+            },
+            {
+                "name": "Spectre",
+                "multiplier": 1
+            },
+            {
+                "name": "Dragon",
+                "multiplier": 0
+            },
+            {
+                "name": "T\u00E9nèbres",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Acier",
+                "multiplier": 2
+            },
+            {
+                "name": "F\u00E9e",
+                "multiplier": 0.5
+            }
+        ],
+        "evolution": null,
+        "height": "1,4 m",
+        "weight": "30,1 kg",
+        "egg_groups": null,
+        "sexe": {
+            "male": 100,
+            "female": 0
+        },
+        "catch_rate": 3,
+        "level_100": 1250000,
+        "formes": null
     },
-    "types": [
-      {
-        "name": "\u00C9lectrik",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/electrik.png"
-      },
-      {
-        "name": "Dragon",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/dragon.png"
-      }
-    ],
-    "talents": [
-      {
-        "name": "Pal\u00e9osynth\u00e8se",
-        "tc": false
-      }
-    ],
-    "stats": {
-      "hp": 125,
-      "atk": 73,
-      "def": 91,
-      "spe_atk": 137,
-      "spe_def": 89,
-      "vit": 75
+    {
+        "pokedex_id": 1017,
+        "generation": 9,
+        "category": "Pok\u00E9mon Masque",
+        "name": {
+            "fr": "Ogerpon",
+            "en": "Ogerpon",
+            "jp": "オーガポン"
+        },
+        "sprites": {
+            "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1017/regular.png",
+            "shiny": null,
+            "gmax": null
+        },
+        "types": [
+            {
+                "name": "Plante",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/plante.png"
+            }
+        ],
+        "talents": [
+            {
+                "name": "Acharn\u00E9",
+                "tc": false
+            },
+            {
+                "name": "Force M\u00E9morielle",
+                "tc": true
+            }
+        ],
+        "stats": {
+            "hp": 80,
+            "atk": 120,
+            "def": 84,
+            "spe_atk": 60,
+            "spe_def": 96,
+            "vit": 110
+        },
+        "resistances": [
+            {
+                "name": "Normal",
+                "multiplier": 1
+            },
+            {
+                "name": "Plante",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Feu",
+                "multiplier": 2
+            },
+            {
+                "name": "Eau",
+                "multiplier": 0.5
+            },
+            {
+                "name": "\u00C9lectrik",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Glace",
+                "multiplier": 2
+            },
+            {
+                "name": "Combat",
+                "multiplier": 1
+            },
+            {
+                "name": "Poison",
+                "multiplier": 2
+            },
+            {
+                "name": "Sol",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Vol",
+                "multiplier": 2
+            },
+            {
+                "name": "Psy",
+                "multiplier": 1
+            },
+            {
+                "name": "Insecte",
+                "multiplier": 2
+            },
+            {
+                "name": "Roche",
+                "multiplier": 1
+            },
+            {
+                "name": "Spectre",
+                "multiplier": 1
+            },
+            {
+                "name": "Dragon",
+                "multiplier": 1
+            },
+            {
+                "name": "T\u00E9nèbres",
+                "multiplier": 1
+            },
+            {
+                "name": "Acier",
+                "multiplier": 1
+            },
+            {
+                "name": "F\u00E9e",
+                "multiplier": 1
+            }
+        ],
+        "evolution": null,
+        "height": "1,2 m",
+        "weight": "39,8 kg",
+        "egg_groups": null,
+        "sexe": {
+            "male": 0,
+            "female": 100
+        },
+        "catch_rate": 5,
+        "level_100": 1250000,
+        "formes": null
     },
-    "resistances": [
-      {
-        "name": "Normal",
-        "multiplier": 1
-      },
-      {
-        "name": "Plante",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Feu",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Eau",
-        "multiplier": 0.5
-      },
-      {
-        "name": "\u00C9lectrik",
-        "multiplier": 0.25
-      },
-      {
-        "name": "Glace",
-        "multiplier": 2
-      },
-      {
-        "name": "Combat",
-        "multiplier": 1
-      },
-      {
-        "name": "Poison",
-        "multiplier": 1
-      },
-      {
-        "name": "Sol",
-        "multiplier": 2
-      },
-      {
-        "name": "Vol",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Psy",
-        "multiplier": 1
-      },
-      {
-        "name": "Insecte",
-        "multiplier": 1
-      },
-      {
-        "name": "Roche",
-        "multiplier": 1
-      },
-      {
-        "name": "Spectre",
-        "multiplier": 1
-      },
-      {
-        "name": "Dragon",
-        "multiplier": 2
-      },
-      {
-        "name": "T\u00E9nèbres",
-        "multiplier": 1
-      },
-      {
-        "name": "Acier",
-        "multiplier": 0.5
-      },
-      {
-        "name": "F\u00E9e",
-        "multiplier": 2
-      }
-    ],
-    "evolution": null,
-    "height": "5,2 m",
-    "weight": "480,0 kg",
-    "egg_groups": null,
-    "sexe": null,
-    "catch_rate": 10,
-    "level_100": 1250000,
-    "formes": null
-  },
-  {
-    "pokedex_id": 1022,
-    "generation": 9,
-    "category": "Pok\u00E9mon Paradoxe",
-    "name": {
-      "fr": "Roc-de-Fer",
-      "en": "Iron Boulder",
-      "jp": "\u30C6\u30C4\u30CE\u30A4\u30EF\u30AA"
+    {
+        "pokedex_id": 1018,
+        "generation": 9,
+        "category": "Pok\u00E9mon Alliage",
+        "name": {
+            "fr": "Pondralugon",
+            "en": "Archaludon",
+            "jp": "\u30D6\u30EA\u30B8\u30E5\u30E9\u30B9"
+        },
+        "sprites": {
+            "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1018/regular.png",
+            "shiny": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1018/shiny.png",
+            "gmax": null
+        },
+        "types": [
+            {
+                "name": "Acier",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/acier.png"
+            },
+            {
+                "name": "Dragon",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/dragon.png"
+            }
+        ],
+        "talents": [
+            {
+                "name": "Endurance",
+                "tc": false
+            },
+            {
+                "name": "Fermet\u00e9",
+                "tc": false
+            },
+            {
+                "name": "Nerfs d'Acier",
+                "tc": true
+            }
+        ],
+        "stats": {
+            "hp": 90,
+            "atk": 105,
+            "def": 130,
+            "spe_atk": 125,
+            "spe_def": 65,
+            "vit": 85
+        },
+        "resistances": [
+            {
+                "name": "Normal",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Plante",
+                "multiplier": 0.25
+            },
+            {
+                "name": "Feu",
+                "multiplier": 1
+            },
+            {
+                "name": "Eau",
+                "multiplier": 0.5
+            },
+            {
+                "name": "\u00C9lectrik",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Glace",
+                "multiplier": 1
+            },
+            {
+                "name": "Combat",
+                "multiplier": 2
+            },
+            {
+                "name": "Poison",
+                "multiplier": 0
+            },
+            {
+                "name": "Sol",
+                "multiplier": 2
+            },
+            {
+                "name": "Vol",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Psy",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Insecte",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Roche",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Spectre",
+                "multiplier": 1
+            },
+            {
+                "name": "Dragon",
+                "multiplier": 1
+            },
+            {
+                "name": "T\u00E9nèbres",
+                "multiplier": 1
+            },
+            {
+                "name": "Acier",
+                "multiplier": 0.5
+            },
+            {
+                "name": "F\u00E9e",
+                "multiplier": 1
+            }
+        ],
+        "evolution": {
+            "pre": [
+                {
+                    "pokedex_id": 884,
+                    "name": "Duralugon",
+                    "condition": "Avec un Métal Composite"
+                }
+            ],
+            "next": null,
+            "mega": null
+        },
+        "height": "2,0 m",
+        "weight": "60,0 kg",
+        "egg_groups": [
+            "Min\u00E9ral",
+            "Draconique"
+        ],
+        "sexe": {
+            "male": 50,
+            "female": 50
+        },
+        "catch_rate": 10,
+        "level_100": 1000000,
+        "formes": null
     },
-    "sprites": {
-      "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1022/regular.png",
-      "shiny": null,
-      "gmax": null
+    {
+        "pokedex_id": 1019,
+        "generation": 9,
+        "category": "Pok\u00E9mon Hydre Pomme",
+        "name": {
+            "fr": "Pomdorochi",
+            "en": "Hydrapple",
+            "jp": "\u30AB\u30DF\u30C4\u30AA\u30ED\u30C1"
+        },
+        "sprites": {
+            "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1019/regular.png",
+            "shiny": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1019/shiny.png",
+            "gmax": null
+        },
+        "types": [
+            {
+                "name": "Plante",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/plante.png"
+            },
+            {
+                "name": "Dragon",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/dragon.png"
+            }
+        ],
+        "talents": [
+            {
+                "name": "Nectar Mielleux",
+                "tc": false
+            },
+            {
+                "name": "R\u00e9g\u00e9-Force",
+                "tc": false
+            },
+            {
+                "name": "Glu",
+                "tc": true
+            }
+        ],
+        "stats": {
+            "hp": 106,
+            "atk": 80,
+            "def": 110,
+            "spe_atk": 120,
+            "spe_def": 80,
+            "vit": 44
+        },
+        "resistances": [
+            {
+                "name": "Normal",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Plante",
+                "multiplier": 0.25
+            },
+            {
+                "name": "Feu",
+                "multiplier": 1
+            },
+            {
+                "name": "Eau",
+                "multiplier": 0.25
+            },
+            {
+                "name": "\u00C9lectrik",
+                "multiplier": 0.25
+            },
+            {
+                "name": "Glace",
+                "multiplier": 4
+            },
+            {
+                "name": "Combat",
+                "multiplier": 1
+            },
+            {
+                "name": "Poison",
+                "multiplier": 2
+            },
+            {
+                "name": "Sol",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Vol",
+                "multiplier": 2
+            },
+            {
+                "name": "Psy",
+                "multiplier": 1
+            },
+            {
+                "name": "Insecte",
+                "multiplier": 2
+            },
+            {
+                "name": "Roche",
+                "multiplier": 1
+            },
+            {
+                "name": "Spectre",
+                "multiplier": 1
+            },
+            {
+                "name": "Dragon",
+                "multiplier": 2
+            },
+            {
+                "name": "T\u00E9nèbres",
+                "multiplier": 1
+            },
+            {
+                "name": "Acier",
+                "multiplier": 1
+            },
+            {
+                "name": "F\u00E9e",
+                "multiplier": 2
+            }
+        ],
+        "evolution": {
+            "pre": [
+                {
+                    "pokedex_id": 840,
+                    "name": "Verpom",
+                    "condition": "Avec une Pomme Nectar"
+                },
+                {
+                    "pokedex_id": 1011,
+                    "name": "Pomdramour",
+                    "condition": "Connaitre Cri Draconique + 1 niveau"
+                }
+            ],
+            "next": null,
+            "mega": null
+        },
+        "height": "1,8 m",
+        "weight": "93,0 kg",
+        "egg_groups": [
+            "V\u00E9g\u00E9tal",
+            "Draconique"
+        ],
+        "sexe": {
+            "male": 50,
+            "female": 50
+        },
+        "catch_rate": 10,
+        "level_100": 600000,
+        "formes": null
     },
-    "types": [
-      {
-        "name": "Roche",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/roche.png"
-      },
-      {
-        "name": "Psy",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/psy.png"
-      }
-    ],
-    "talents": [
-      {
-        "name": "Charge Quantique",
-        "tc": false
-      }
-    ],
-    "stats": {
-      "hp": 90,
-      "atk": 120,
-      "def": 80,
-      "spe_atk": 68,
-      "spe_def": 108,
-      "vit": 124
+    {
+        "pokedex_id": 1020,
+        "generation": 9,
+        "category": "Pok\u00E9mon Paradoxe",
+        "name": {
+            "fr": "Feu-Per\u00E7ant",
+            "en": "Gouging Fire",
+            "jp": "\u30A6\u30AC\u30C4\u30DB\u30E0\u30E9"
+        },
+        "sprites": {
+            "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1020/regular.png",
+            "shiny": null,
+            "gmax": null
+        },
+        "types": [
+            {
+                "name": "Feu",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/feu.png"
+            },
+            {
+                "name": "Dragon",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/dragon.png"
+            }
+        ],
+        "talents": [
+            {
+                "name": "Pal\u00e9osynth\u00e8se",
+                "tc": false
+            }
+        ],
+        "stats": {
+            "hp": 105,
+            "atk": 115,
+            "def": 121,
+            "spe_atk": 65,
+            "spe_def": 93,
+            "vit": 91
+        },
+        "resistances": [
+            {
+                "name": "Normal",
+                "multiplier": 1
+            },
+            {
+                "name": "Plante",
+                "multiplier": 0.25
+            },
+            {
+                "name": "Feu",
+                "multiplier": 0.25
+            },
+            {
+                "name": "Eau",
+                "multiplier": 1
+            },
+            {
+                "name": "\u00C9lectrik",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Glace",
+                "multiplier": 1
+            },
+            {
+                "name": "Combat",
+                "multiplier": 1
+            },
+            {
+                "name": "Poison",
+                "multiplier": 1
+            },
+            {
+                "name": "Sol",
+                "multiplier": 2
+            },
+            {
+                "name": "Vol",
+                "multiplier": 1
+            },
+            {
+                "name": "Psy",
+                "multiplier": 1
+            },
+            {
+                "name": "Insecte",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Roche",
+                "multiplier": 2
+            },
+            {
+                "name": "Spectre",
+                "multiplier": 1
+            },
+            {
+                "name": "Dragon",
+                "multiplier": 2
+            },
+            {
+                "name": "T\u00E9nèbres",
+                "multiplier": 1
+            },
+            {
+                "name": "Acier",
+                "multiplier": 0.5
+            },
+            {
+                "name": "F\u00E9e",
+                "multiplier": 1
+            }
+        ],
+        "evolution": null,
+        "height": "3,5 m",
+        "weight": "590,0 kg",
+        "egg_groups": null,
+        "sexe": null,
+        "catch_rate": 10,
+        "level_100": 1250000,
+        "formes": null
     },
-    "resistances": [
-      {
-        "name": "Normal",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Plante",
-        "multiplier": 2
-      },
-      {
-        "name": "Feu",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Eau",
-        "multiplier": 2
-      },
-      {
-        "name": "\u00C9lectrik",
-        "multiplier": 1
-      },
-      {
-        "name": "Glace",
-        "multiplier": 1
-      },
-      {
-        "name": "Combat",
-        "multiplier": 1
-      },
-      {
-        "name": "Poison",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Sol",
-        "multiplier": 2
-      },
-      {
-        "name": "Vol",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Psy",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Insecte",
-        "multiplier": 2
-      },
-      {
-        "name": "Roche",
-        "multiplier": 1
-      },
-      {
-        "name": "Spectre",
-        "multiplier": 2
-      },
-      {
-        "name": "Dragon",
-        "multiplier": 1
-      },
-      {
-        "name": "T\u00E9nèbres",
-        "multiplier": 2
-      },
-      {
-        "name": "Acier",
-        "multiplier": 2
-      },
-      {
-        "name": "F\u00E9e",
-        "multiplier": 1
-      }
-    ],
-    "evolution": null,
-    "height": "1,5 m",
-    "weight": "162,5 kg",
-    "egg_groups": null,
-    "sexe": null,
-    "catch_rate": 10,
-    "level_100": 1250000,
-    "formes": null
-  },
-  {
-    "pokedex_id": 1023,
-    "generation": 9,
-    "category": "Pok\u00E9mon Paradoxe",
-    "name": {
-      "fr": "Chef-de-Fer",
-      "en": "Iron Crown",
-      "jp": "\u30C6\u30C4\u30CE\u30AB\u30B7\u30E9"
+    {
+        "pokedex_id": 1021,
+        "generation": 9,
+        "category": "Pok\u00E9mon Paradoxe",
+        "name": {
+            "fr": "Ire-Foudre",
+            "en": "Raging Bolt",
+            "jp": "\u30BF\u30B1\u30EB\u30E9\u30A4\u30B3"
+        },
+        "sprites": {
+            "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1021/regular.png",
+            "shiny": null,
+            "gmax": null
+        },
+        "types": [
+            {
+                "name": "\u00C9lectrik",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/electrik.png"
+            },
+            {
+                "name": "Dragon",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/dragon.png"
+            }
+        ],
+        "talents": [
+            {
+                "name": "Pal\u00e9osynth\u00e8se",
+                "tc": false
+            }
+        ],
+        "stats": {
+            "hp": 125,
+            "atk": 73,
+            "def": 91,
+            "spe_atk": 137,
+            "spe_def": 89,
+            "vit": 75
+        },
+        "resistances": [
+            {
+                "name": "Normal",
+                "multiplier": 1
+            },
+            {
+                "name": "Plante",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Feu",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Eau",
+                "multiplier": 0.5
+            },
+            {
+                "name": "\u00C9lectrik",
+                "multiplier": 0.25
+            },
+            {
+                "name": "Glace",
+                "multiplier": 2
+            },
+            {
+                "name": "Combat",
+                "multiplier": 1
+            },
+            {
+                "name": "Poison",
+                "multiplier": 1
+            },
+            {
+                "name": "Sol",
+                "multiplier": 2
+            },
+            {
+                "name": "Vol",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Psy",
+                "multiplier": 1
+            },
+            {
+                "name": "Insecte",
+                "multiplier": 1
+            },
+            {
+                "name": "Roche",
+                "multiplier": 1
+            },
+            {
+                "name": "Spectre",
+                "multiplier": 1
+            },
+            {
+                "name": "Dragon",
+                "multiplier": 2
+            },
+            {
+                "name": "T\u00E9nèbres",
+                "multiplier": 1
+            },
+            {
+                "name": "Acier",
+                "multiplier": 0.5
+            },
+            {
+                "name": "F\u00E9e",
+                "multiplier": 2
+            }
+        ],
+        "evolution": null,
+        "height": "5,2 m",
+        "weight": "480,0 kg",
+        "egg_groups": null,
+        "sexe": null,
+        "catch_rate": 10,
+        "level_100": 1250000,
+        "formes": null
     },
-    "sprites": {
-      "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1023/regular.png",
-      "shiny": null,
-      "gmax": null
+    {
+        "pokedex_id": 1022,
+        "generation": 9,
+        "category": "Pok\u00E9mon Paradoxe",
+        "name": {
+            "fr": "Roc-de-Fer",
+            "en": "Iron Boulder",
+            "jp": "\u30C6\u30C4\u30CE\u30A4\u30EF\u30AA"
+        },
+        "sprites": {
+            "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1022/regular.png",
+            "shiny": null,
+            "gmax": null
+        },
+        "types": [
+            {
+                "name": "Roche",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/roche.png"
+            },
+            {
+                "name": "Psy",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/psy.png"
+            }
+        ],
+        "talents": [
+            {
+                "name": "Charge Quantique",
+                "tc": false
+            }
+        ],
+        "stats": {
+            "hp": 90,
+            "atk": 120,
+            "def": 80,
+            "spe_atk": 68,
+            "spe_def": 108,
+            "vit": 124
+        },
+        "resistances": [
+            {
+                "name": "Normal",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Plante",
+                "multiplier": 2
+            },
+            {
+                "name": "Feu",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Eau",
+                "multiplier": 2
+            },
+            {
+                "name": "\u00C9lectrik",
+                "multiplier": 1
+            },
+            {
+                "name": "Glace",
+                "multiplier": 1
+            },
+            {
+                "name": "Combat",
+                "multiplier": 1
+            },
+            {
+                "name": "Poison",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Sol",
+                "multiplier": 2
+            },
+            {
+                "name": "Vol",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Psy",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Insecte",
+                "multiplier": 2
+            },
+            {
+                "name": "Roche",
+                "multiplier": 1
+            },
+            {
+                "name": "Spectre",
+                "multiplier": 2
+            },
+            {
+                "name": "Dragon",
+                "multiplier": 1
+            },
+            {
+                "name": "T\u00E9nèbres",
+                "multiplier": 2
+            },
+            {
+                "name": "Acier",
+                "multiplier": 2
+            },
+            {
+                "name": "F\u00E9e",
+                "multiplier": 1
+            }
+        ],
+        "evolution": null,
+        "height": "1,5 m",
+        "weight": "162,5 kg",
+        "egg_groups": null,
+        "sexe": null,
+        "catch_rate": 10,
+        "level_100": 1250000,
+        "formes": null
     },
-    "types": [
-      {
-        "name": "Acier",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/acier.png"
-      },
-      {
-        "name": "Psy",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/psy.png"
-      }
-    ],
-    "talents": [
-      {
-        "name": "Charge Quantique",
-        "tc": false
-      }
-    ],
-    "stats": {
-      "hp": 90,
-      "atk": 72,
-      "def": 100,
-      "spe_atk": 122,
-      "spe_def": 108,
-      "vit": 98
+    {
+        "pokedex_id": 1023,
+        "generation": 9,
+        "category": "Pok\u00E9mon Paradoxe",
+        "name": {
+            "fr": "Chef-de-Fer",
+            "en": "Iron Crown",
+            "jp": "\u30C6\u30C4\u30CE\u30AB\u30B7\u30E9"
+        },
+        "sprites": {
+            "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1023/regular.png",
+            "shiny": null,
+            "gmax": null
+        },
+        "types": [
+            {
+                "name": "Acier",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/acier.png"
+            },
+            {
+                "name": "Psy",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/psy.png"
+            }
+        ],
+        "talents": [
+            {
+                "name": "Charge Quantique",
+                "tc": false
+            }
+        ],
+        "stats": {
+            "hp": 90,
+            "atk": 72,
+            "def": 100,
+            "spe_atk": 122,
+            "spe_def": 108,
+            "vit": 98
+        },
+        "resistances": [
+            {
+                "name": "Normal",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Plante",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Feu",
+                "multiplier": 2
+            },
+            {
+                "name": "Eau",
+                "multiplier": 1
+            },
+            {
+                "name": "\u00C9lectrik",
+                "multiplier": 1
+            },
+            {
+                "name": "Glace",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Combat",
+                "multiplier": 1
+            },
+            {
+                "name": "Poison",
+                "multiplier": 0
+            },
+            {
+                "name": "Sol",
+                "multiplier": 2
+            },
+            {
+                "name": "Vol",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Psy",
+                "multiplier": 0.25
+            },
+            {
+                "name": "Insecte",
+                "multiplier": 1
+            },
+            {
+                "name": "Roche",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Spectre",
+                "multiplier": 2
+            },
+            {
+                "name": "Dragon",
+                "multiplier": 0.5
+            },
+            {
+                "name": "T\u00E9nèbres",
+                "multiplier": 2
+            },
+            {
+                "name": "Acier",
+                "multiplier": 0.5
+            },
+            {
+                "name": "F\u00E9e",
+                "multiplier": 0.5
+            }
+        ],
+        "evolution": null,
+        "height": "1,6 m",
+        "weight": "156,0 kg",
+        "egg_groups": null,
+        "sexe": null,
+        "catch_rate": 10,
+        "level_100": 1250000,
+        "formes": null
     },
-    "resistances": [
-      {
-        "name": "Normal",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Plante",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Feu",
-        "multiplier": 2
-      },
-      {
-        "name": "Eau",
-        "multiplier": 1
-      },
-      {
-        "name": "\u00C9lectrik",
-        "multiplier": 1
-      },
-      {
-        "name": "Glace",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Combat",
-        "multiplier": 1
-      },
-      {
-        "name": "Poison",
-        "multiplier": 0
-      },
-      {
-        "name": "Sol",
-        "multiplier": 2
-      },
-      {
-        "name": "Vol",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Psy",
-        "multiplier": 0.25
-      },
-      {
-        "name": "Insecte",
-        "multiplier": 1
-      },
-      {
-        "name": "Roche",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Spectre",
-        "multiplier": 2
-      },
-      {
-        "name": "Dragon",
-        "multiplier": 0.5
-      },
-      {
-        "name": "T\u00E9nèbres",
-        "multiplier": 2
-      },
-      {
-        "name": "Acier",
-        "multiplier": 0.5
-      },
-      {
-        "name": "F\u00E9e",
-        "multiplier": 0.5
-      }
-    ],
-    "evolution": null,
-    "height": "1,6 m",
-    "weight": "156,0 kg",
-    "egg_groups": null,
-    "sexe": null,
-    "catch_rate": 10,
-    "level_100": 1250000,
-    "formes": null
-  },
-  {
-    "pokedex_id": 1024,
-    "generation": 9,
-    "category": "Pok\u00E9mon T\u00E9racristal",
-    "name": {
-      "fr": "Terapagos",
-      "en": "Terapagos",
-      "jp": "\u30C6\u30E9\u30D1\u30B4\u30B9"
+    {
+        "pokedex_id": 1024,
+        "generation": 9,
+        "category": "Pok\u00E9mon T\u00E9racristal",
+        "name": {
+            "fr": "Terapagos",
+            "en": "Terapagos",
+            "jp": "\u30C6\u30E9\u30D1\u30B4\u30B9"
+        },
+        "sprites": {
+            "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1024/regular.png",
+            "shiny": null,
+            "gmax": null
+        },
+        "types": [
+            {
+                "name": "Normal",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/normal.png"
+            }
+        ],
+        "talents": [
+            {
+                "name": "T\u00E9ramorphose",
+                "tc": false
+            }
+        ],
+        "stats": {
+            "hp": 90,
+            "atk": 65,
+            "def": 85,
+            "spe_atk": 65,
+            "spe_def": 85,
+            "vit": 60
+        },
+        "resistances": [
+            {
+                "name": "Normal",
+                "multiplier": 1
+            },
+            {
+                "name": "Plante",
+                "multiplier": 1
+            },
+            {
+                "name": "Feu",
+                "multiplier": 1
+            },
+            {
+                "name": "Eau",
+                "multiplier": 1
+            },
+            {
+                "name": "\u00C9lectrik",
+                "multiplier": 1
+            },
+            {
+                "name": "Glace",
+                "multiplier": 1
+            },
+            {
+                "name": "Combat",
+                "multiplier": 2
+            },
+            {
+                "name": "Poison",
+                "multiplier": 1
+            },
+            {
+                "name": "Sol",
+                "multiplier": 1
+            },
+            {
+                "name": "Vol",
+                "multiplier": 1
+            },
+            {
+                "name": "Psy",
+                "multiplier": 1
+            },
+            {
+                "name": "Insecte",
+                "multiplier": 1
+            },
+            {
+                "name": "Roche",
+                "multiplier": 1
+            },
+            {
+                "name": "Spectre",
+                "multiplier": 0
+            },
+            {
+                "name": "Dragon",
+                "multiplier": 1
+            },
+            {
+                "name": "T\u00E9nèbres",
+                "multiplier": 1
+            },
+            {
+                "name": "Acier",
+                "multiplier": 1
+            },
+            {
+                "name": "F\u00E9e",
+                "multiplier": 1
+            }
+        ],
+        "evolution": null,
+        "height": "3,5 m",
+        "weight": "590,0 kg",
+        "egg_groups": null,
+        "sexe": {
+            "male": 50,
+            "female": 50
+        },
+        "catch_rate": 255,
+        "level_100": 1250000,
+        "formes": null
     },
-    "sprites": {
-      "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1024/regular.png",
-      "shiny": null,
-      "gmax": null
-    },
-    "types": [
-      {
-        "name": "Normal",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/normal.png"
-      }
-    ],
-    "talents": [
-      {
-        "name": "T\u00E9ramorphose",
-        "tc": false
-      }
-    ],
-    "stats": {
-      "hp": 90,
-      "atk": 65,
-      "def": 85,
-      "spe_atk": 65,
-      "spe_def": 85,
-      "vit": 60
-    },
-    "resistances": [
-      {
-        "name": "Normal",
-        "multiplier": 1
-      },
-      {
-        "name": "Plante",
-        "multiplier": 1
-      },
-      {
-        "name": "Feu",
-        "multiplier": 1
-      },
-      {
-        "name": "Eau",
-        "multiplier": 1
-      },
-      {
-        "name": "\u00C9lectrik",
-        "multiplier": 1
-      },
-      {
-        "name": "Glace",
-        "multiplier": 1
-      },
-      {
-        "name": "Combat",
-        "multiplier": 2
-      },
-      {
-        "name": "Poison",
-        "multiplier": 1
-      },
-      {
-        "name": "Sol",
-        "multiplier": 1
-      },
-      {
-        "name": "Vol",
-        "multiplier": 1
-      },
-      {
-        "name": "Psy",
-        "multiplier": 1
-      },
-      {
-        "name": "Insecte",
-        "multiplier": 1
-      },
-      {
-        "name": "Roche",
-        "multiplier": 1
-      },
-      {
-        "name": "Spectre",
-        "multiplier": 0
-      },
-      {
-        "name": "Dragon",
-        "multiplier": 1
-      },
-      {
-        "name": "T\u00E9nèbres",
-        "multiplier": 1
-      },
-      {
-        "name": "Acier",
-        "multiplier": 1
-      },
-      {
-        "name": "F\u00E9e",
-        "multiplier": 1
-      }
-    ],
-    "evolution": null,
-    "height": "3,5 m",
-    "weight": "590,0 kg",
-    "egg_groups": null,
-    "sexe": {
-      "male": 50,
-      "female": 50
-    },
-    "catch_rate": 255,
-    "level_100": 1250000,
-    "formes": null
-  },
-  {
-    "pokedex_id": 1025,
-    "generation": 9,
-    "category": "Pok\u00E9mon Emprise",
-    "name": {
-      "fr": "P\u00EAchaminus",
-      "en": "Pecharunt",
-      "jp": "\u30E2\u30E2\u30EF\u30ED\u30A6"
-    },
-    "sprites": {
-      "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1025/regular.png",
-      "shiny": null,
-      "gmax": null
-    },
-    "types": [
-      {
-        "name": "Poison",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/poison.png"
-      },
-      {
-        "name": "Spectre",
-        "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/spectre.png"
-      }
-    ],
-    "talents": [
-      {
-        "name": "Emprise Toxique",
-        "tc": false
-      }
-    ],
-    "stats": {
-      "hp": 88,
-      "atk": 88,
-      "def": 160,
-      "spe_atk": 88,
-      "spe_def": 88,
-      "vit": 88
-    },
-    "resistances": [
-      {
-        "name": "Normal",
-        "multiplier": 0
-      },
-      {
-        "name": "Plante",
-        "multiplier": 0.5
-      },
-      {
-        "name": "Feu",
-        "multiplier": 1
-      },
-      {
-        "name": "Eau",
-        "multiplier": 1
-      },
-      {
-        "name": "\u00C9lectrik",
-        "multiplier": 1
-      },
-      {
-        "name": "Glace",
-        "multiplier": 1
-      },
-      {
-        "name": "Combat",
-        "multiplier": 0
-      },
-      {
-        "name": "Poison",
-        "multiplier": 0.25
-      },
-      {
-        "name": "Sol",
-        "multiplier": 2
-      },
-      {
-        "name": "Vol",
-        "multiplier": 1
-      },
-      {
-        "name": "Psy",
-        "multiplier": 2
-      },
-      {
-        "name": "Insecte",
-        "multiplier": 0.25
-      },
-      {
-        "name": "Roche",
-        "multiplier": 1
-      },
-      {
-        "name": "Spectre",
-        "multiplier": 2
-      },
-      {
-        "name": "Dragon",
-        "multiplier": 1
-      },
-      {
-        "name": "T\u00E9nèbres",
-        "multiplier": 2
-      },
-      {
-        "name": "Acier",
-        "multiplier": 1
-      },
-      {
-        "name": "F\u00E9e",
-        "multiplier": 0.5
-      }
-    ],
-    "evolution": null,
-    "height": "0,3 m",
-    "weight": "0,3 kg",
-    "egg_groups": null,
-    "sexe": null,
-    "catch_rate": 3,
-    "level_100": 1250000,
-    "formes": null
-  }
+    {
+        "pokedex_id": 1025,
+        "generation": 9,
+        "category": "Pok\u00E9mon Emprise",
+        "name": {
+            "fr": "P\u00EAchaminus",
+            "en": "Pecharunt",
+            "jp": "\u30E2\u30E2\u30EF\u30ED\u30A6"
+        },
+        "sprites": {
+            "regular": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/sprites/1025/regular.png",
+            "shiny": null,
+            "gmax": null
+        },
+        "types": [
+            {
+                "name": "Poison",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/poison.png"
+            },
+            {
+                "name": "Spectre",
+                "image": "https://raw.githubusercontent.com/Yarkis01/TyraDex/images/types/spectre.png"
+            }
+        ],
+        "talents": [
+            {
+                "name": "Emprise Toxique",
+                "tc": false
+            }
+        ],
+        "stats": {
+            "hp": 88,
+            "atk": 88,
+            "def": 160,
+            "spe_atk": 88,
+            "spe_def": 88,
+            "vit": 88
+        },
+        "resistances": [
+            {
+                "name": "Normal",
+                "multiplier": 0
+            },
+            {
+                "name": "Plante",
+                "multiplier": 0.5
+            },
+            {
+                "name": "Feu",
+                "multiplier": 1
+            },
+            {
+                "name": "Eau",
+                "multiplier": 1
+            },
+            {
+                "name": "\u00C9lectrik",
+                "multiplier": 1
+            },
+            {
+                "name": "Glace",
+                "multiplier": 1
+            },
+            {
+                "name": "Combat",
+                "multiplier": 0
+            },
+            {
+                "name": "Poison",
+                "multiplier": 0.25
+            },
+            {
+                "name": "Sol",
+                "multiplier": 2
+            },
+            {
+                "name": "Vol",
+                "multiplier": 1
+            },
+            {
+                "name": "Psy",
+                "multiplier": 2
+            },
+            {
+                "name": "Insecte",
+                "multiplier": 0.25
+            },
+            {
+                "name": "Roche",
+                "multiplier": 1
+            },
+            {
+                "name": "Spectre",
+                "multiplier": 2
+            },
+            {
+                "name": "Dragon",
+                "multiplier": 1
+            },
+            {
+                "name": "T\u00E9nèbres",
+                "multiplier": 2
+            },
+            {
+                "name": "Acier",
+                "multiplier": 1
+            },
+            {
+                "name": "F\u00E9e",
+                "multiplier": 0.5
+            }
+        ],
+        "evolution": null,
+        "height": "0,3 m",
+        "weight": "0,3 kg",
+        "egg_groups": null,
+        "sexe": null,
+        "catch_rate": 3,
+        "level_100": 1250000,
+        "formes": null
+    }
 ]


### PR DESCRIPTION
This pull request makes updates to the `pokemon.json` file to improve data consistency and completeness.

### Default Values:
* Updated several fields (`types`, `talents`, `stats`, `resistances`, `height`, `weight`, `catch_rate`, `level_100`) to have default values instead of `null`. For example, `stats` now has a structure with all attributes initialized to `0`, and `height`/`weight` are set to empty strings.
* Only the "Fake" Pokemon 0 was missing those fields so I think i would be better for users who need strongly typed apis

### Data Enhancements:
* Added missing evolution conditions for Solgaleo namely "Cosmog" (Level 43) and "Cosmovum" (Level 53).
* Fixed a typo in the evolution condition for "Zapétrel" (from `"conditio"` to `"condition"`).

### Formatting Improvements:
* Reformatted `egg_groups` fields to use multi-line arrays for better readability.
* Fixed inconsistent spaces