### PR TITLE
fix: missing data in pokemon when research with the type & adding possibility to search with two types

### DIFF
--- a/src/main/java/tyradexteam/tyradex/controllers/TypeController.java
+++ b/src/main/java/tyradexteam/tyradex/controllers/TypeController.java
@@ -53,4 +53,16 @@ public class TypeController {
     public List<PokemonDTO> getPokemonByType(@PathVariable String type1) {
         return this.pokemonService.getPokemonByType(type1);
     }
+
+    /**
+     * Endpoint to retrieve Pokemon entities based on their two types. This method will handle HTTP requests to the "/type/{type1}/{type2}"
+     * @param type1 The Type of Pokemon to filter by, which can be provided in either French or English. The endpoint will match Pokemon nodes that are connected to a TypePokemon node with the specified name.
+     * @param type2 The second Type of Pokemon to filter by, which can be provided in either French or English. The endpoint will match Pokemon nodes that are connected to a TypePokemon node with the specified name.
+     * @return A list of Pokemon entities that match the specified types, retrived from the service layer, which in turn interacts with the repository to fetch data from the database.
+     */
+    @GetMapping(value = "{type1}/{type2}", produces = "application/json")
+    @Operation(summary = "Retrieve Pokemon by Two Types", description = "Endpoint to retrieve Pokemon) entities based on their two types. The endpoint will match Pokemon nodes that are connected to two TypePokemon nodes with the specified names, which can be provided in either French or English.")
+    public List<PokemonDTO> getPokemonByType(@PathVariable String type1, @PathVariable String type2) {
+        return this.pokemonService.getPokemonByTypes(type1, type2);
+    }
 }

--- a/src/main/java/tyradexteam/tyradex/services/PokemonService.java
+++ b/src/main/java/tyradexteam/tyradex/services/PokemonService.java
@@ -55,6 +55,10 @@ public class PokemonService {
         return this.mapper.toDTO(this.repo.findByType(type1.toLowerCase()));
     }
 
+    public List<PokemonDTO> getPokemonByTypes(String type1, String type2) {
+        return this.mapper.toDTO(this.repo.findByDoubleType(type1.toLowerCase(), type2.toLowerCase()));
+    }
+
     /**
      * Method to retrieve a Pokemon entity based on its unique identifier (ID). This method interacts with the repository to fetch data
      * @param id The unique identifier of the Pokemon to retrieve. The method attempts to find a Pokemon with the specified ID and returns it as a DTO.

--- a/src/main/java/tyradexteam/tyradex/services/repositories/PokemonRepository.java
+++ b/src/main/java/tyradexteam/tyradex/services/repositories/PokemonRepository.java
@@ -48,11 +48,28 @@ public interface PokemonRepository extends PagingAndSortingRepository<Pokemon, I
 
     /**
      * Custom query to find Pokemon by their type. This method uses a Cypher query to match Pokemon nodes that are connected
-     * @param type The type of Pokemon to filter by, which can be provided in either French or English. The query matches Pokemon nodes that are connected to a TypePokemon node with the specified name.
+     * @param type1 The type of Pokemon to filter by, which can be provided in either French or English. The query matches Pokemon nodes that are connected to a TypePokemon node with the specified name.
      * @return A list of Pokemon entities that match the specified type, retrieved from the database.
      */
-    @Query("MATCH (p:Pokemon)-[:IS_TYPED]->(t:TypePokemon) WHERE toLower(t.name_fr) = $type OR toLower(t.name_en) = $type ORDER BY p.pokedex_id ASC RETURN p;")
-    List<Pokemon> findByType(String type);
+    @Query(
+    """
+        MATCH (t:TypePokemon)<-[r_t:IS_TYPED]-(p:Pokemon), (p)-[r:IS_TYPED|GROUPED_IN|HAS|WAS|NEXT]-(m)
+        WHERE toLower(t.name_fr) = $type1 OR toLower(t.name_en) = $type1
+        RETURN p, collect(r), collect(m), collect(t), collect(r_t)
+        ORDER BY p.pokedex_id ASC;
+    """)
+    List<Pokemon> findByType(String type1);
+
+    @Query(
+    """
+        MATCH (t:TypePokemon)<-[r_t:IS_TYPED]-(p:Pokemon)-[r_t2:IS_TYPED]->(t2:TypePokemon), (p)-[r:IS_TYPED|GROUPED_IN|HAS|WAS|NEXT]-(m)
+        WHERE (toLower(t.name_fr) = $type1 OR toLower(t.name_en) = $type1)
+          AND (toLower(t2.name_fr) = $type2 OR toLower(t2.name_en) = $type2)
+        RETURN p, collect(r), collect(m), collect(t), collect(r_t), collect(t2), collect(r_t2)
+        ORDER BY p.pokedex_id ASC;
+    """
+    )
+    List<Pokemon> findByDoubleType(String type1, String type2);
 
     /**
      * Custom query to find Pokemon by their generation. This method uses a Cypher query to match Pokemon nodes that have a specific generation property.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,5 +11,4 @@ springdoc.swagger-ui.path=/swagger
 
 app.bank.img.url=https://raw.githubusercontent.com/TyradexTeam/Sprites/refs/heads/main/
 
-spring.mvc.throw-exception-if-no-handler-found=true
 spring.web.resources.add-mappings=false


### PR DESCRIPTION
This pull request introduces support for querying Pokémon by two types, enhancing the application's API and database query capabilities. The main changes include the addition of a new endpoint, corresponding service and repository methods, and an updated Cypher query to fetch Pokémon with both specified types.

**API Enhancements:**
* Added a new REST endpoint to `TypeController` that allows fetching Pokémon by two types, accepting both French and English type names.

**Service Layer Updates:**
* Implemented a `getPokemonByTypes` method in `PokemonService` to handle the new double-type query and delegate to the repository.

**Repository and Database Query Improvements:**
* Added a new `findByDoubleType` method in `PokemonRepository` with a custom Cypher query to match Pokémon nodes connected to both specified types.
* Updated the existing `findByType` query and its documentation for clarity and consistency with the new double-type method.

**Configuration Cleanup:**
* Removed the unused `spring.mvc.throw-exception-if-no-handler-found` property from `application.properties`.